### PR TITLE
fix: playground content overflow

### DIFF
--- a/lib/components/playground/dynamic-live.tsx
+++ b/lib/components/playground/dynamic-live.tsx
@@ -28,6 +28,7 @@ const DynamicLive: React.FC<Props> = ({ code, scope }) => {
           display: flex;
           flex-direction: column;
           box-sizing: border-box;
+          overflow-x: scroll;
         }
 
         .wrapper > :global(div) {


### PR DESCRIPTION
## Change information

Fixes Playground Content Overflow

Before:

<img width="441" alt="Screenshot 2021-06-24 at 9 17 50 AM" src="https://user-images.githubusercontent.com/61158210/123199733-0e67cd00-d4cd-11eb-80c3-4a34068ad478.png">

After:


<img width="400" alt="Screenshot 2021-06-24 at 9 18 20 AM" src="https://user-images.githubusercontent.com/61158210/123199770-1fb0d980-d4cd-11eb-9159-45f4a583f3e7.png">

