### PR TITLE
chore: simplify the type srouce of third-party lib

### DIFF
--- a/components/css-baseline/css-baseline.tsx
+++ b/components/css-baseline/css-baseline.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 import useTheme from '../use-theme'
 import flush from 'styled-jsx/server'
-import flushToReact from 'styled-jsx/server'
+
+export type FlushToReact = <T>(opts?: { nonce?: string }) => Array<ReactElement<T>>
 
 const CssBaseline: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const theme = useTheme()
@@ -302,7 +303,7 @@ const CssBaseline: React.FC<React.PropsWithChildren<unknown>> = ({ children }) =
 }
 
 type MemoCssBaselineComponent<P = {}> = React.NamedExoticComponent<P> & {
-  flush: typeof flushToReact
+  flush: FlushToReact
 }
 
 const MemoCssBaseline = React.memo(CssBaseline) as MemoCssBaselineComponent<

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geist-ui/core",
-  "version": "2.2.4",
+  "version": "2.2.4-dev.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",
@@ -87,6 +87,7 @@
     "inter-ui": "^3.19.3",
     "jest": "^27.0.5",
     "next": "^12.0.9-canary.0",
+    "styled-jsx": "4.0.1",
     "prettier": "^2.3.1",
     "react": "^17.0.2",
     "react-color": "^2.19.3",
@@ -102,8 +103,7 @@
     "typescript-transform-paths": "^3.3.1"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.7",
-    "styled-jsx": "4.0.1"
+    "@babel/runtime": "^7.16.7"
   },
   "peerDependencies": {
     "react": ">=16.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geist-ui/core",
-  "version": "2.2.4-dev.3",
+  "version": "2.2.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",

--- a/typings/styled.d.ts
+++ b/typings/styled.d.ts
@@ -1,9 +1,10 @@
-declare global {
-  declare module 'react' {
-    interface StyleHTMLAttributes<T> extends React.HTMLAttributes<T> {
-      jsx?: boolean;
-      global?: boolean;
-    }
+// Definitions by: @types/styled-jsx <https://www.npmjs.com/package/@types/styled-jsx>
+
+import 'react'
+
+declare module 'react' {
+  interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
+    jsx?: boolean
+    global?: boolean
   }
 }
-


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

- Simplify the type of export within a component
- Remove the type from `styled-jsx` (there is only one reference)

