### PR TITLE
feat(button): slightly reduce the default width

### DIFF
--- a/components/button/__tests__/__snapshots__/icon.test.tsx.snap
+++ b/components/button/__tests__/__snapshots__/icon.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`ButtonIcon should render correctly 1`] = `
             --geist-ui-button-height: calc(2.5 * 16px);
             --geist-ui-button-color: #666;
             --geist-ui-button-bg: #fff;
-            min-width: calc(12.5 * 16px);
+            min-width: calc(10.5 * 16px);
             width: initial;
             height: calc(2.5 * 16px);
             padding: 0 calc(1.375 * 16px) 0 calc(1.375 * 16px);
@@ -168,7 +168,7 @@ exports[`ButtonIcon should work with right 1`] = `
             --geist-ui-button-height: calc(2.5 * 16px);
             --geist-ui-button-color: #666;
             --geist-ui-button-bg: #fff;
-            min-width: calc(12.5 * 16px);
+            min-width: calc(10.5 * 16px);
             width: initial;
             height: calc(2.5 * 16px);
             padding: 0 calc(1.375 * 16px) 0 calc(1.375 * 16px);
@@ -264,7 +264,7 @@ exports[`ButtonIcon should work without text 1`] = `
             --geist-ui-button-height: calc(2.5 * 16px);
             --geist-ui-button-color: #666;
             --geist-ui-button-bg: #fff;
-            min-width: calc(12.5 * 16px);
+            min-width: calc(10.5 * 16px);
             width: initial;
             height: calc(2.5 * 16px);
             padding: 0 calc(1.375 * 16px) 0 calc(1.375 * 16px);

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -177,7 +177,7 @@ const ButtonComponent = React.forwardRef<
             --geist-ui-button-height: ${SCALES.height(2.5)};
             --geist-ui-button-color: ${color};
             --geist-ui-button-bg: ${bg};
-            min-width: ${auto ? 'min-content' : SCALES.width(12.5)};
+            min-width: ${auto ? 'min-content' : SCALES.width(10.5)};
             width: ${auto ? 'auto' : 'initial'};
             height: ${SCALES.height(2.5)};
             padding: ${SCALES.pt(0)} ${paddingRight} ${SCALES.pb(0)} ${paddingLeft};

--- a/components/modal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/index.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`Modal should render correctly 1`] = `
             --geist-ui-button-height: calc(2.5 * 16px);
             --geist-ui-button-color: #666;
             --geist-ui-button-bg: #fff;
-            min-width: calc(12.5 * 16px);
+            min-width: calc(10.5 * 16px);
             width: initial;
             height: calc(2.5 * 16px);
             padding: 0 calc(1.375 * 16px) 0 calc(1.375 * 16px);
@@ -224,7 +224,7 @@ exports[`Modal should render correctly 1`] = `
             --geist-ui-button-height: calc(2.5 * 16px);
             --geist-ui-button-color: #666;
             --geist-ui-button-bg: #fff;
-            min-width: calc(12.5 * 16px);
+            min-width: calc(10.5 * 16px);
             width: initial;
             height: calc(2.5 * 16px);
             padding: 0 calc(1.375 * 16px) 0 calc(1.375 * 16px);


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

Slightly reduce the default `width` of the `Button` to avoid imbalance when over-scaling.
