### PR TITLE
feat(toast): redesign hooks to compatible with placement and styles

### DIFF
--- a/components/geist-provider/geist-provider.tsx
+++ b/components/geist-provider/geist-provider.tsx
@@ -1,8 +1,9 @@
-import React, { PropsWithChildren, useMemo } from 'react'
+import React, { PropsWithChildren, useMemo, useState } from 'react'
 import {
   GeistUIContent,
   GeistUIContextParams,
   UpdateToastsFunction,
+  UpdateToastsIDFunction,
   UpdateToastsLayoutFunction,
 } from '../utils/use-geist-ui-context'
 import ThemeProvider from './theme-provider'
@@ -21,6 +22,8 @@ const GeistProvider: React.FC<PropsWithChildren<GeistProviderProps>> = ({
   themeType,
   children,
 }) => {
+  const [lastUpdateToastId, setLastUpdateToastId] =
+    useState<GeistUIContextParams['lastUpdateToastId']>(null)
   const [toasts, setToasts, toastsRef] = useCurrentState<GeistUIContextParams['toasts']>(
     [],
   )
@@ -34,15 +37,20 @@ const GeistProvider: React.FC<PropsWithChildren<GeistProviderProps>> = ({
     const nextLayout = fn(toastLayoutRef.current)
     setToastLayout(nextLayout)
   }
+  const updateLastToastId: UpdateToastsIDFunction = fn => {
+    setLastUpdateToastId(fn())
+  }
 
   const initialValue = useMemo<GeistUIContextParams>(
     () => ({
       toasts,
       toastLayout,
       updateToasts,
+      lastUpdateToastId,
       updateToastLayout,
+      updateLastToastId,
     }),
-    [toasts, toastLayout],
+    [toasts, toastLayout, lastUpdateToastId],
   )
 
   return (

--- a/components/geist-provider/geist-provider.tsx
+++ b/components/geist-provider/geist-provider.tsx
@@ -1,13 +1,15 @@
-import React, { PropsWithChildren, useMemo, useState } from 'react'
+import React, { PropsWithChildren, useMemo } from 'react'
 import {
   GeistUIContent,
   GeistUIContextParams,
   UpdateToastsFunction,
+  UpdateToastsLayoutFunction,
 } from '../utils/use-geist-ui-context'
 import ThemeProvider from './theme-provider'
 import useCurrentState from '../utils/use-current-state'
-import ToastContainer, { ToastWithID } from '../use-toasts/toast-container'
+import ToastContainer from '../use-toasts/toast-container'
 import { GeistUIThemes } from '../themes/presets'
+import { defaultToastLayout } from '../use-toasts/use-toast'
 
 export type GeistProviderProps = {
   themes?: Array<GeistUIThemes>
@@ -19,28 +21,28 @@ const GeistProvider: React.FC<PropsWithChildren<GeistProviderProps>> = ({
   themeType,
   children,
 }) => {
-  const [toasts, setToasts, toastsRef] = useCurrentState<Array<ToastWithID>>([])
-  const [toastHovering, setToastHovering] = useState<boolean>(false)
-  const updateToasts: UpdateToastsFunction<ToastWithID> = (
-    fn: (toasts: ToastWithID[]) => ToastWithID[],
-  ) => {
+  const [toasts, setToasts, toastsRef] = useCurrentState<GeistUIContextParams['toasts']>(
+    [],
+  )
+  const [toastLayout, setToastLayout, toastLayoutRef] =
+    useCurrentState<GeistUIContextParams['toastLayout']>(defaultToastLayout)
+  const updateToasts: UpdateToastsFunction = fn => {
     const nextToasts = fn(toastsRef.current)
     setToasts(nextToasts)
   }
-
-  const updateToastHoverStatus = (fn: () => boolean) => {
-    const nextHoverStatus = fn()
-    setToastHovering(nextHoverStatus)
+  const updateToastLayout: UpdateToastsLayoutFunction = fn => {
+    const nextLayout = fn(toastLayoutRef.current)
+    setToastLayout(nextLayout)
   }
 
   const initialValue = useMemo<GeistUIContextParams>(
     () => ({
       toasts,
-      toastHovering,
+      toastLayout,
       updateToasts,
-      updateToastHoverStatus,
+      updateToastLayout,
     }),
-    [toasts, toastHovering],
+    [toasts, toastLayout],
   )
 
   return (

--- a/components/index.ts
+++ b/components/index.ts
@@ -172,7 +172,7 @@ export { default as useAllThemes } from './use-all-themes'
 export type { AllThemesConfig } from './use-all-themes'
 
 export { default as useToasts } from './use-toasts'
-export type { Toast } from './use-toasts'
+export type { Toast, ToastInput, ToastAction, ToastLayout } from './use-toasts'
 
 export { default as User } from './user'
 export type { UserProps } from './user'

--- a/components/snippet/snippet.tsx
+++ b/components/snippet/snippet.tsx
@@ -54,7 +54,7 @@ const SnippetComponent: React.FC<React.PropsWithChildren<SnippetProps>> = ({
   const theme = useTheme()
   const { SCALES } = useScale()
   const { copy } = useClipboard()
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const ref = useRef<HTMLPreElement>(null)
   const isMultiLine = text && Array.isArray(text)
 

--- a/components/use-toasts/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/use-toasts/__tests__/__snapshots__/index.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`UseToast should render different actions 1`] = `
           .btn {
             box-sizing: border-box;
             display: inline-block;
-            line-height: calc(2.083333333333333 * 16px);
+            line-height: calc(1.6666666666666665 * 16px);
             border-radius: 6px;
             font-weight: 400;
-            font-size: calc(0.7291666666666666 * 16px);
+            font-size: 13px;
             user-select: none;
             outline: none;
             text-transform: capitalize;
@@ -25,14 +25,14 @@ exports[`UseToast should render different actions 1`] = `
             cursor: pointer;
             pointer-events: auto;
             box-shadow: none;
-            --geist-ui-button-icon-padding: calc(0.6058333333333332 * 16px);
-            --geist-ui-button-height: calc(2.083333333333333 * 16px);
+            --geist-ui-button-icon-padding: calc(0.48466666666666663 * 16px);
+            --geist-ui-button-height: calc(1.6666666666666665 * 16px);
             --geist-ui-button-color: #fff;
             --geist-ui-button-bg: #000;
             min-width: min-content;
             width: auto;
-            height: calc(2.083333333333333 * 16px);
-            padding: 0 calc(0.9583333333333331 * 16px) 0 calc(0.9583333333333331 * 16px);
+            height: calc(1.6666666666666665 * 16px);
+            padding: 0 calc(0.7666666666666666 * 16px) 0 calc(0.7666666666666666 * 16px);
             margin: 0 0 0 0;
           }
 
@@ -68,10 +68,10 @@ exports[`UseToast should render different actions 1`] = `
           .btn {
             box-sizing: border-box;
             display: inline-block;
-            line-height: calc(2.083333333333333 * 16px);
+            line-height: calc(1.6666666666666665 * 16px);
             border-radius: 6px;
             font-weight: 400;
-            font-size: calc(0.7291666666666666 * 16px);
+            font-size: 13px;
             user-select: none;
             outline: none;
             text-transform: capitalize;
@@ -88,14 +88,14 @@ exports[`UseToast should render different actions 1`] = `
             cursor: pointer;
             pointer-events: auto;
             box-shadow: none;
-            --geist-ui-button-icon-padding: calc(0.6058333333333332 * 16px);
-            --geist-ui-button-height: calc(2.083333333333333 * 16px);
+            --geist-ui-button-icon-padding: calc(0.48466666666666663 * 16px);
+            --geist-ui-button-height: calc(1.6666666666666665 * 16px);
             --geist-ui-button-color: #666;
             --geist-ui-button-bg: #fff;
             min-width: min-content;
             width: auto;
-            height: calc(2.083333333333333 * 16px);
-            padding: 0 calc(0.9583333333333331 * 16px) 0 calc(0.9583333333333331 * 16px);
+            height: calc(1.6666666666666665 * 16px);
+            padding: 0 calc(0.7666666666666666 * 16px) 0 calc(0.7666666666666666 * 16px);
             margin: 0 0 0 0;
           }
 

--- a/components/use-toasts/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/use-toasts/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UseToast should render different actions 1`] = `
-"<div class=\\"toast-container \\"><div class=\\"toast  \\"><div class=\\"message\\">hello</div><div class=\\"action\\"><button type=\\"button\\" class=\\"btn \\"><div class=\\"text\\">remove</div><style>
+"<div class=\\"toasts\\"><div class=\\"toast  toast-enter\\"><div class=\\"message\\">hello</div><div class=\\"action\\"><button type=\\"button\\" class=\\"btn \\"><div class=\\"text\\">remove</div><style>
           .btn {
             box-sizing: border-box;
             display: inline-block;
@@ -140,33 +140,15 @@ exports[`UseToast should render different actions 1`] = `
             color: #000;
             border: 0;
             border-radius: 6px;
-            padding: 16pt;
-            position: absolute;
-            bottom: 0;
-            right: 0;
             opacity: 1;
             box-shadow: 0 5px 10px rgba(0, 0, 0, 0.12);
-            transform: translate3d(0, 100%, 0px) scale(1);
-            transition: transform 400ms ease 0ms, visibility 200ms ease 0ms,
-              opacity 200ms ease 0ms;
+            transition: all 350ms cubic-bezier(0.1, 0.2, 0.1, 1);
+            overflow: hidden;
           }
-
-          .toast.visible {
-            opacity: 1;
-            transform: translate3d(0, calc(100% + -75px + -0px), -0px) scale(1);
-          }
-
-          .toast.hide {
-            opacity: 0;
-            visibility: hidden;
-            pointer-events: none;
-          }
-
           .message {
             align-items: center;
             height: 100%;
-            transition: opacity 0.4s ease;
-            font-size: 0.875rem;
+            font-size: 0.875em;
             display: -webkit-box;
             word-break: break-all;
             padding-right: 8pt;
@@ -177,30 +159,58 @@ exports[`UseToast should render different actions 1`] = `
             -webkit-line-clamp: 2;
             line-height: 1.1rem;
           }
-
-          .toast :global(button + button) {
-            margin-left: 4pt;
+          .toast-enter {
+            opacity: 0;
+            height: 0;
+            padding: 0;
+            margin: 0;
+            transform: translate(60px, 60px);
+          }
+          .toast-enter-active {
+            opacity: 1;
+            height: auto;
+            margin: 8px 0;
+            padding: 12px 16px;
+            transform: translate(0, 0);
+          }
+          .toast-leave {
+            opacity: 1;
+            transform: translate(0, 0);
+            height: auto;
+            margin: 8px 0;
+            padding: 12px 16px;
+          }
+          .toast-leave-active {
+            opacity: 0;
+            transform: translate(50px, -15px) scale(0.85);
           }
         </style></div><style>
-        .toast-container {
+        .toasts {
           position: fixed;
-          width: 420px;
-          max-width: 90vw;
-          bottom: 16pt;
+          width: auto;
+          max-width: 100%;
           right: 16pt;
+          bottom: 16pt;
           z-index: 2000;
           transition: all 400ms ease;
           box-sizing: border-box;
+          display: flex;
+          flex-direction: column;
         }
-
-        .toast-container.hover {
-          transform: translate3d(0, -10px, 0);
+        .top {
+          bottom: unset;
+          flex-direction: column-reverse;
+          top: 16pt;
+        }
+        .left {
+          right: unset;
+          left: 16pt;
         }
       </style></div>"
 `;
 
 exports[`UseToast should work with different types 1`] = `
-"<div class=\\"toast-container \\"><div class=\\"toast visible \\"><div class=\\"message\\">hello</div><div class=\\"action\\"></div><style>
+"<div class=\\"toasts\\"><div class=\\"toast  toast-enter toast-enter-active\\"><div class=\\"message\\">hello</div><div class=\\"action\\"></div><style>
           .toast {
             width: 420px;
             max-width: 90vw;
@@ -213,33 +223,15 @@ exports[`UseToast should work with different types 1`] = `
             color: white;
             border: 0;
             border-radius: 6px;
-            padding: 16pt;
-            position: absolute;
-            bottom: 0;
-            right: 0;
             opacity: 1;
             box-shadow: 0 5px 10px rgba(0, 0, 0, 0.12);
-            transform: translate3d(0, 100%, 0px) scale(1);
-            transition: transform 400ms ease 0ms, visibility 200ms ease 0ms,
-              opacity 200ms ease 0ms;
+            transition: all 350ms cubic-bezier(0.1, 0.2, 0.1, 1);
+            overflow: hidden;
           }
-
-          .toast.visible {
-            opacity: 1;
-            transform: translate3d(0, calc(100% + -75px + -0px), -0px) scale(1);
-          }
-
-          .toast.hide {
-            opacity: 0;
-            visibility: hidden;
-            pointer-events: none;
-          }
-
           .message {
             align-items: center;
             height: 100%;
-            transition: opacity 0.4s ease;
-            font-size: 0.875rem;
+            font-size: 0.875em;
             display: -webkit-box;
             word-break: break-all;
             padding-right: 8pt;
@@ -250,24 +242,52 @@ exports[`UseToast should work with different types 1`] = `
             -webkit-line-clamp: 2;
             line-height: 1.1rem;
           }
-
-          .toast :global(button + button) {
-            margin-left: 4pt;
+          .toast-enter {
+            opacity: 0;
+            height: 0;
+            padding: 0;
+            margin: 0;
+            transform: translate(60px, 60px);
+          }
+          .toast-enter-active {
+            opacity: 1;
+            height: auto;
+            margin: 8px 0;
+            padding: 12px 16px;
+            transform: translate(0, 0);
+          }
+          .toast-leave {
+            opacity: 1;
+            transform: translate(0, 0);
+            height: auto;
+            margin: 8px 0;
+            padding: 12px 16px;
+          }
+          .toast-leave-active {
+            opacity: 0;
+            transform: translate(50px, -15px) scale(0.85);
           }
         </style></div><style>
-        .toast-container {
+        .toasts {
           position: fixed;
-          width: 420px;
-          max-width: 90vw;
-          bottom: 16pt;
+          width: auto;
+          max-width: 100%;
           right: 16pt;
+          bottom: 16pt;
           z-index: 2000;
           transition: all 400ms ease;
           box-sizing: border-box;
+          display: flex;
+          flex-direction: column;
         }
-
-        .toast-container.hover {
-          transform: translate3d(0, -10px, 0);
+        .top {
+          bottom: unset;
+          flex-direction: column-reverse;
+          top: 16pt;
+        }
+        .left {
+          right: unset;
+          left: 16pt;
         }
       </style></div>"
 `;

--- a/components/use-toasts/__tests__/index.test.tsx
+++ b/components/use-toasts/__tests__/index.test.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 import { mount, ReactWrapper } from 'enzyme'
 import { useToasts, GeistProvider } from 'components'
 import { nativeEvent, updateWrapper } from 'tests/utils'
+import { ToastInput } from '../use-toast'
 
 const MockToast: React.FC<unknown> = () => {
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const clickHandler = (e: any = {}) => {
     const keys = ['text', 'delay', 'type', 'actions']
     const params = keys.reduce((pre, key) => {
@@ -12,7 +13,7 @@ const MockToast: React.FC<unknown> = () => {
       if (!value) return pre
       return { ...pre, [key]: value }
     }, {})
-    setToast(params)
+    setToast(params as ToastInput)
   }
   return (
     <div id="btn" onClick={clickHandler}>
@@ -29,12 +30,12 @@ const triggerToast = (wrapper: ReactWrapper, params = {}) => {
 }
 
 const expectToastIsShow = (wrapper: ReactWrapper) => {
-  const toast = wrapper.find('.toast-container').find('.toast')
+  const toast = wrapper.find('.toasts').find('.toast')
   expect(toast.length).not.toBe(0)
 }
 
 const expectToastIsHidden = (wrapper: ReactWrapper) => {
-  const toast = wrapper.find('.toast-container').find('.toast')
+  const toast = wrapper.find('.toasts').find('.toast')
   expect(toast.length).toBe(0)
 }
 
@@ -63,7 +64,7 @@ describe('UseToast', () => {
     triggerToast(wrapper, { type: 'success', text: 'hello' })
     await updateWrapper(wrapper, 100)
     expectToastIsShow(wrapper)
-    expect(wrapper.find('.toast-container').html()).toMatchSnapshot()
+    expect(wrapper.find('.toasts').html()).toMatchSnapshot()
   })
 
   it('should close toast', async () => {
@@ -79,7 +80,7 @@ describe('UseToast', () => {
     expectToastIsShow(wrapper)
     // Element already hidden, but Dom was removed after delay
     await updateWrapper(wrapper, 350)
-    const toast = wrapper.find('.toast-container').find('.hide')
+    const toast = wrapper.find('.toasts').find('.toast')
     expect(toast.length).not.toBe(0)
   })
 
@@ -95,18 +96,18 @@ describe('UseToast', () => {
     await updateWrapper(wrapper, 0)
     expectToastIsShow(wrapper)
 
-    wrapper.find('.toast-container').simulate('mouseEnter', nativeEvent)
+    wrapper.find('.toasts').simulate('mouseEnter', nativeEvent)
     await updateWrapper(wrapper, 350)
 
     // Hover event will postpone hidden event
-    let toast = wrapper.find('.toast-container').find('.hide')
-    expect(toast.length).toBe(0)
+    let toast = wrapper.find('.toasts').find('.toast')
+    expect(toast.length).not.toBe(0)
 
     // Restart hidden event after mouse leave
-    wrapper.find('.toast-container').simulate('mouseLeave', nativeEvent)
+    wrapper.find('.toasts').simulate('mouseLeave', nativeEvent)
     await updateWrapper(wrapper, 350 + 200)
-    toast = wrapper.find('.toast-container').find('.hide')
-    expect(toast.length).not.toBe(0)
+    toast = wrapper.find('.toasts').find('.toast')
+    expect(toast.length).toBe(0)
   })
 
   it('should render different actions', async () => {
@@ -130,7 +131,7 @@ describe('UseToast', () => {
     triggerToast(wrapper, { actions, text: 'hello' })
     await updateWrapper(wrapper)
     expectToastIsShow(wrapper)
-    expect(wrapper.find('.toast-container').html()).toMatchSnapshot()
+    expect(wrapper.find('.toasts').html()).toMatchSnapshot()
   })
 
   it('should close toast when action triggered', async () => {
@@ -154,7 +155,7 @@ describe('UseToast', () => {
 
     // Element already hidden, but Dom was removed after delay
     await updateWrapper(wrapper, 250)
-    const toast = wrapper.find('.toast-container').find('.hide')
+    const toast = wrapper.find('.toasts').find('.toast')
     expect(toast.length).not.toBe(0)
   })
 
@@ -181,7 +182,7 @@ describe('UseToast', () => {
     expectToastIsShow(wrapper)
 
     await updateWrapper(wrapper, 200)
-    const toast = wrapper.find('.toast-container').find('.hide')
+    const toast = wrapper.find('.toasts').find('.toast')
     expect(toast.length).not.toBe(0)
   })
 })

--- a/components/use-toasts/helpers.tsx
+++ b/components/use-toasts/helpers.tsx
@@ -1,0 +1,83 @@
+import { Toast, ToastAction } from './use-toast'
+import React from 'react'
+import Button from '../button'
+import { GeistUIThemesPalette } from '../themes'
+import { NormalTypes, tuple } from '../utils/prop-types'
+
+export const makeToastActions = (actions: Toast['actions'], cancelHandle: () => void) => {
+  const handler = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    userHandler: ToastAction['handler'],
+  ) => {
+    userHandler && userHandler(event, cancelHandle)
+  }
+  if (!actions || !actions.length) return null
+  return actions.map((action, index) => (
+    <Button
+      auto
+      scale={2 / 3}
+      type={action.passive ? 'default' : 'secondary'}
+      key={`action-${index}`}
+      onClick={(event: React.MouseEvent<HTMLButtonElement>) =>
+        handler(event, action.handler)
+      }>
+      {action.name}
+    </Button>
+  ))
+}
+
+export const getColors = (palette: GeistUIThemesPalette, type?: NormalTypes) => {
+  const colors: { [key in NormalTypes]: string } = {
+    default: palette.background,
+    secondary: palette.secondary,
+    success: palette.success,
+    warning: palette.warning,
+    error: palette.error,
+  }
+  const isDefault = !type || type === 'default'
+  if (isDefault)
+    return {
+      bgColor: colors.default,
+      color: palette.foreground,
+    }
+  /**
+   * Prevent main color change in special types.
+   * The color will only follow the theme when it is in the default type.
+   */
+  return {
+    bgColor: colors[type as NormalTypes],
+    color: 'white',
+  }
+}
+
+const toastPlacement = tuple('topLeft', 'topRight', 'bottomLeft', 'bottomRight')
+export type ToastPlacement = typeof toastPlacement[number]
+
+export const isTopPlacement = (placement: ToastPlacement) =>
+  `${placement}`.toLowerCase().startsWith('top')
+export const isLeftPlacement = (placement: ToastPlacement) =>
+  `${placement}`.toLowerCase().endsWith('left')
+
+export const getTranslateByPlacement = (
+  placement: ToastPlacement,
+): {
+  enter: string
+  leave: string
+} => {
+  const translateInByPlacement: Record<ToastPlacement, string> = {
+    topLeft: 'translate(-60px, -60px)',
+    topRight: 'translate(60px, -60px)',
+    bottomLeft: 'translate(-60px, 60px)',
+    bottomRight: 'translate(60px, 60px)',
+  }
+  const translateOutByPlacement: Record<ToastPlacement, string> = {
+    topLeft: 'translate(-50px, 15px) scale(0.85)',
+    topRight: 'translate(50px, 15px) scale(0.85)',
+    bottomLeft: 'translate(-50px, -15px) scale(0.85)',
+    bottomRight: 'translate(50px, -15px) scale(0.85)',
+  }
+  return {
+    enter: translateInByPlacement[placement],
+    leave: translateOutByPlacement[placement],
+  }
+}

--- a/components/use-toasts/helpers.tsx
+++ b/components/use-toasts/helpers.tsx
@@ -15,7 +15,8 @@ export const makeToastActions = (actions: Toast['actions'], cancelHandle: () => 
   return actions.map((action, index) => (
     <Button
       auto
-      scale={2 / 3}
+      scale={1 / 3}
+      font="13px"
       type={action.passive ? 'default' : 'secondary'}
       key={`action-${index}`}
       onClick={(event: React.MouseEvent<HTMLButtonElement>) =>

--- a/components/use-toasts/index.ts
+++ b/components/use-toasts/index.ts
@@ -1,4 +1,4 @@
 import useToasts from './use-toast'
 
-export type { ToastAction, Toast, ToastTypes } from './use-toast'
+export type { ToastAction, Toast, ToastTypes, ToastInput, ToastLayout } from './use-toast'
 export default useToasts

--- a/components/use-toasts/toast-container.tsx
+++ b/components/use-toasts/toast-container.tsx
@@ -1,71 +1,109 @@
-import React, { useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import usePortal from '../utils/use-portal'
 import useTheme from '../use-theme'
 import { useGeistUIContext } from '../utils/use-geist-ui-context'
-import { Toast } from './use-toast'
 import ToastItem from './toast-item'
-
-export type ToastWithID = Toast & {
-  id: string
-  willBeDestroy?: boolean
-  cancel: () => void
-}
+import useClasses from '../use-classes'
+import { isLeftPlacement, isTopPlacement } from './helpers'
 
 const ToastContainer: React.FC<React.PropsWithChildren<unknown>> = () => {
-  const portal = usePortal('toast')
   const theme = useTheme()
-  const [hover, setHover] = useState<boolean>(false)
-  const timer = useRef<number | undefined>()
-  const { toasts, updateToastHoverStatus } = useGeistUIContext()
+  const portal = usePortal('toast')
+  const { toasts, updateToasts, toastLayout } = useGeistUIContext()
+  const memoizedLayout = useMemo(() => toastLayout, [toastLayout])
   const toastElements = useMemo(
     () =>
-      toasts.map((t, i) => (
-        <ToastItem
-          index={i}
-          total={toasts.length}
-          toast={t}
-          onHover={hover}
-          key={`toast-${i}`}
-        />
+      toasts.map(toast => (
+        <ToastItem toast={toast} layout={memoizedLayout} key={toast._internalIdent} />
       )),
-    [toasts, hover],
+    [toasts, memoizedLayout],
   )
-  const hoverHandler = (onHover: boolean) => {
-    if (onHover) {
-      timer.current && clearTimeout(timer.current)
-      updateToastHoverStatus(() => true)
-      return setHover(true)
-    }
-    timer.current = window.setTimeout(() => {
-      setHover(false)
-      updateToastHoverStatus(() => false)
-      timer.current && clearTimeout(timer.current)
-    }, 200)
+  const classNames = useMemo(
+    () =>
+      useClasses('toasts', {
+        top: isTopPlacement(toastLayout.placement),
+        left: isLeftPlacement(toastLayout.placement),
+      }),
+    [memoizedLayout],
+  )
+  const hoverHandler = (isHovering: boolean) => {
+    if (isHovering)
+      return updateToasts(last =>
+        last.map(toast => {
+          if (!toast.visible) return toast
+          toast._timeout && window.clearTimeout(toast._timeout)
+          return {
+            ...toast,
+            timeout: null,
+          }
+        }),
+      )
+
+    updateToasts(last =>
+      last.map((toast, index) => {
+        if (!toast.visible) return toast
+        toast._timeout && window.clearTimeout(toast._timeout)
+        return {
+          ...toast,
+          _timeout: (() => {
+            const timer = window.setTimeout(() => {
+              toast.cancel()
+              window.clearTimeout(timer)
+            }, toast.delay + index * 100)
+            return timer
+          })(),
+        }
+      }),
+    )
   }
+
+  useEffect(() => {
+    let timeout: null | number = null
+    const timer = window.setInterval(() => {
+      if (toasts.length === 0) return
+      timeout = window.setTimeout(() => {
+        const allInvisible = !toasts.find(r => r.visible)
+        allInvisible && updateToasts(() => [])
+        timeout && clearTimeout(timeout)
+      }, 350)
+    }, 5000)
+
+    return () => {
+      timer && clearInterval(timer)
+      timeout && clearTimeout(timeout)
+    }
+  }, [toasts])
 
   if (!portal) return null
   if (!toasts || toasts.length === 0) return null
   return createPortal(
     <div
-      className={`toast-container ${hover ? 'hover' : ''}`}
-      onMouseEnter={() => hoverHandler(true)}
-      onMouseLeave={() => hoverHandler(false)}>
+      className={classNames}
+      onMouseOver={() => hoverHandler(true)}
+      onMouseOut={() => hoverHandler(false)}>
       {toastElements}
       <style jsx>{`
-        .toast-container {
+        .toasts {
           position: fixed;
-          width: 420px;
-          max-width: 90vw;
-          bottom: ${theme.layout.gap};
+          width: auto;
+          max-width: 100%;
           right: ${theme.layout.gap};
+          bottom: ${theme.layout.gap};
           z-index: 2000;
           transition: all 400ms ease;
           box-sizing: border-box;
+          display: flex;
+          flex-direction: column;
         }
-
-        .toast-container.hover {
-          transform: translate3d(0, -10px, 0);
+        .top {
+          bottom: unset;
+          flex-direction: column-reverse;
+          top: ${theme.layout.gap};
+        }
+        .left {
+          right: unset;
+          left: ${theme.layout.gap};
         }
       `}</style>
     </div>,

--- a/components/use-toasts/toast-item.tsx
+++ b/components/use-toasts/toast-item.tsx
@@ -1,127 +1,41 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import useTheme from '../use-theme'
-import { Toast, ToastAction } from './use-toast'
-import Button from '../button'
-import { NormalTypes } from '../utils/prop-types'
-import { GeistUIThemesPalette } from '../themes/presets'
+import type { Toast, ToastLayout } from './use-toast'
+import CssTransition from '../shared/css-transition'
+import { makeToastActions, getColors, getTranslateByPlacement } from './helpers'
 
-type ToastWithID = Toast & {
-  id: string
-  willBeDestroy?: boolean
-  cancel: () => void
+export interface ToastItemProps {
+  toast: Toast
+  layout: Required<ToastLayout>
 }
 
-export interface ToatItemProps {
-  index: number
-  total: number
-  toast: ToastWithID
-  onHover: boolean
-}
+const ToastItem: React.FC<ToastItemProps> = React.memo(({ toast, layout }) => {
+  const theme = useTheme()
+  const { color, bgColor } = useMemo(
+    () => getColors(theme.palette, toast.type),
+    [theme.palette, toast.type],
+  )
+  const isReactNode = typeof toast.text !== 'string'
+  const { padding, margin, maxHeight, maxWidth, width, placement } = layout
+  const { enter, leave } = useMemo(() => getTranslateByPlacement(placement), [placement])
 
-const toastActions = (actions: Toast['actions'], cancelHandle: () => void) => {
-  const handler = (
-    event: React.MouseEvent<HTMLButtonElement>,
-    userHandler: ToastAction['handler'],
-  ) => {
-    userHandler && userHandler(event, cancelHandle)
-  }
-  if (!actions || !actions.length) return null
-  return actions.map((action, index) => (
-    <Button
-      auto
-      scale={2 / 3}
-      type={action.passive ? 'default' : 'secondary'}
-      key={`action-${index}`}
-      onClick={(event: React.MouseEvent<HTMLButtonElement>) =>
-        handler(event, action.handler)
-      }>
-      {action.name}
-    </Button>
-  ))
-}
+  return (
+    <CssTransition name="toast" visible={toast.visible} clearTime={350}>
+      <div key={toast.id} className="toast">
+        {isReactNode ? (
+          toast.text
+        ) : (
+          <>
+            <div className="message">{toast.text}</div>
+            <div className="action">{makeToastActions(toast.actions, toast.cancel)}</div>
+          </>
+        )}
 
-const getColors = (palette: GeistUIThemesPalette, type?: NormalTypes) => {
-  const colors: { [key in NormalTypes]: string } = {
-    default: palette.background,
-    secondary: palette.secondary,
-    success: palette.success,
-    warning: palette.warning,
-    error: palette.error,
-  }
-  const isDefault = !type || type === 'default'
-  if (isDefault)
-    return {
-      bgColor: colors.default,
-      color: palette.foreground,
-    }
-  /**
-   * Prevent main color change in special types.
-   * The color will only follow the theme when it is in the default type.
-   */
-  return {
-    bgColor: colors[type as NormalTypes],
-    color: 'white',
-  }
-}
-
-const ToastItem: React.FC<ToatItemProps> = React.memo(
-  ({ index, total, toast, onHover }) => {
-    const theme = useTheme()
-    const { color, bgColor } = useMemo(() => getColors(theme.palette, toast.type), [
-      theme.palette,
-      toast.type,
-    ])
-    const [visible, setVisible] = useState<boolean>(false)
-    const [hide, setHide] = useState<boolean>(false)
-    const reverseIndex = useMemo(() => total - (index + 1), [total, index])
-    const translate = useMemo(() => {
-      const calc = `100% + -75px + -${20 * reverseIndex}px`
-      if (reverseIndex >= 4) return `translate3d(0, -75px, -${reverseIndex}px) scale(.7)`
-      if (onHover) {
-        return `translate3d(0, ${reverseIndex * -75}px, -${reverseIndex}px) scale(${
-          total === 1 ? 1 : 0.98205
-        })`
-      }
-      return `translate3d(0, calc(${calc}), -${reverseIndex}px) scale(${
-        1 - 0.05 * reverseIndex
-      })`
-    }, [onHover, index, total, reverseIndex])
-
-    useEffect(() => {
-      const timer = setTimeout(() => {
-        setVisible(true)
-        clearTimeout(timer)
-      }, 10)
-      return () => clearTimeout(timer)
-    }, [])
-
-    useEffect(() => {
-      let unMount = false
-      const shouldBeHide = reverseIndex > 2 || toast.willBeDestroy
-      if (!shouldBeHide || unMount) return
-      const timer = setTimeout(() => {
-        setHide(true)
-        clearTimeout(timer)
-      }, 150)
-      return () => {
-        unMount = true
-        clearTimeout(timer)
-      }
-    }, [reverseIndex, toast.willBeDestroy])
-    /* istanbul ignore next */
-    if (reverseIndex > 10) return null
-
-    return (
-      <div
-        key={`${toast.id}-${index}`}
-        className={`toast ${visible ? 'visible' : ''} ${hide ? 'hide' : ''}`}>
-        <div className="message">{toast.text}</div>
-        <div className="action">{toastActions(toast.actions, toast.cancel)}</div>
         <style jsx>{`
           .toast {
-            width: 420px;
-            max-width: 90vw;
-            max-height: 75px;
+            width: ${width};
+            max-width: ${maxWidth};
+            max-height: ${maxHeight};
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -130,33 +44,15 @@ const ToastItem: React.FC<ToatItemProps> = React.memo(
             color: ${color};
             border: 0;
             border-radius: ${theme.layout.radius};
-            padding: ${theme.layout.gap};
-            position: absolute;
-            bottom: 0;
-            right: 0;
-            opacity: ${reverseIndex > 4 ? 0 : 1};
-            box-shadow: ${reverseIndex > 4 ? 'none' : theme.expressiveness.shadowSmall};
-            transform: translate3d(0, 100%, 0px) scale(1);
-            transition: transform 400ms ease 0ms, visibility 200ms ease 0ms,
-              opacity 200ms ease 0ms;
-          }
-
-          .toast.visible {
             opacity: 1;
-            transform: ${translate};
+            box-shadow: ${theme.expressiveness.shadowSmall};
+            transition: all 350ms cubic-bezier(0.1, 0.2, 0.1, 1);
+            overflow: hidden;
           }
-
-          .toast.hide {
-            opacity: 0;
-            visibility: hidden;
-            pointer-events: none;
-          }
-
           .message {
             align-items: center;
             height: 100%;
-            transition: opacity 0.4s ease;
-            font-size: 0.875rem;
+            font-size: 0.875em;
             display: -webkit-box;
             word-break: break-all;
             padding-right: ${theme.layout.gapHalf};
@@ -167,14 +63,35 @@ const ToastItem: React.FC<ToatItemProps> = React.memo(
             -webkit-line-clamp: 2;
             line-height: 1.1rem;
           }
-
-          .toast :global(button + button) {
-            margin-left: ${theme.layout.gapQuarter};
+          .toast-enter {
+            opacity: 0;
+            height: 0;
+            padding: 0;
+            margin: 0;
+            transform: ${enter};
+          }
+          .toast-enter-active {
+            opacity: 1;
+            height: auto;
+            margin: ${margin};
+            padding: ${padding};
+            transform: translate(0, 0);
+          }
+          .toast-leave {
+            opacity: 1;
+            transform: translate(0, 0);
+            height: auto;
+            margin: ${margin};
+            padding: ${padding};
+          }
+          .toast-leave-active {
+            opacity: 0;
+            transform: ${leave};
           }
         `}</style>
       </div>
-    )
-  },
-)
+    </CssTransition>
+  )
+})
 
 export default ToastItem

--- a/components/use-toasts/use-toast.tsx
+++ b/components/use-toasts/use-toast.tsx
@@ -56,7 +56,8 @@ export type ToastHooksResult = {
 }
 
 const useToasts = (layout?: ToastLayout): ToastHooksResult => {
-  const { updateToasts, toasts, updateToastLayout } = useGeistUIContext()
+  const { updateToasts, toasts, updateToastLayout, updateLastToastId } =
+    useGeistUIContext()
 
   useEffect(() => {
     if (!layout) return
@@ -77,6 +78,7 @@ const useToasts = (layout?: ToastLayout): ToastHooksResult => {
         return { ...item, visible: false }
       }),
     )
+    updateLastToastId(() => internalId)
   }
   const removeAll = () => {
     updateToasts(last => last.map(toast => ({ ...toast, visible: false })))

--- a/components/use-toasts/use-toast.tsx
+++ b/components/use-toasts/use-toast.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect } from 'react'
-import { NormalTypes } from '../utils/prop-types'
-import useCurrentState from '../utils/use-current-state'
+import React, { CSSProperties, useEffect } from 'react'
+import type { NormalTypes } from '../utils/prop-types'
 import { useGeistUIContext } from '../utils/use-geist-ui-context'
-import { ToastWithID } from './toast-container'
 import { getId } from '../utils/collections'
+import { ToastPlacement } from '../use-toasts/helpers'
 
 export interface ToastAction {
   name: string
@@ -11,86 +10,129 @@ export interface ToastAction {
   passive?: boolean
 }
 export type ToastTypes = NormalTypes
-export interface Toast {
-  text?: string | React.ReactNode
+export type ToastLayout = {
+  padding?: CSSProperties['padding']
+  margin?: CSSProperties['margin']
+  width?: CSSProperties['width']
+  maxWidth?: CSSProperties['maxWidth']
+  maxHeight?: CSSProperties['maxHeight']
+  placement?: ToastPlacement
+}
+export interface ToastInput {
+  text: string | React.ReactNode
   type?: ToastTypes
+  id?: string
   delay?: number
   actions?: Array<ToastAction>
 }
+export type ToastInstance = {
+  visible: boolean
+  cancel: () => void
+  _timeout: null | number
+  _internalIdent: string
+}
+
+export type Toast = Required<ToastInput> & ToastInstance
 
 const defaultToast = {
   delay: 2000,
+  type: 'default' as ToastTypes,
+}
+export const defaultToastLayout: Required<ToastLayout> = {
+  padding: '12px 16px',
+  margin: '8px 0',
+  width: '420px',
+  maxWidth: '90vw',
+  maxHeight: '75px',
+  placement: 'bottomRight',
 }
 
-let destoryStack: Array<string> = []
-let maxDestoryTime: number = 0
-let destoryTimer: number | undefined
+export type ToastHooksResult = {
+  toasts: Array<Toast>
+  setToast: (toast: ToastInput) => void
+  removeAll: () => void
+  findToastOneByID: (ident: string) => Toast | undefined
+  removeToastOneByID: (ident: string) => void
+}
 
-const useToasts = (): [Array<Toast>, (t: Toast) => void] => {
-  const { updateToasts, toastHovering, toasts } = useGeistUIContext()
-  const [, setHovering, hoveringRef] = useCurrentState<boolean>(toastHovering)
+const useToasts = (layout?: ToastLayout): ToastHooksResult => {
+  const { updateToasts, toasts, updateToastLayout } = useGeistUIContext()
 
-  useEffect(() => setHovering(toastHovering), [toastHovering])
+  useEffect(() => {
+    if (!layout) return
+    updateToastLayout(() =>
+      layout
+        ? {
+            ...defaultToastLayout,
+            ...layout,
+          }
+        : defaultToastLayout,
+    )
+  }, [])
 
-  const destoryAll = (delay: number, time: number) => {
-    /* istanbul ignore next */
-    if (time <= maxDestoryTime) return
-    clearTimeout(destoryTimer)
-    maxDestoryTime = time
-
-    destoryTimer = window.setTimeout(() => {
-      /* istanbul ignore next */
-      updateToasts((currentToasts: Array<ToastWithID>) => {
-        if (destoryStack.length < currentToasts.length) {
-          return currentToasts
+  const cancel = (internalId: string) => {
+    updateToasts((currentToasts: Array<Toast>) =>
+      currentToasts.map(item => {
+        if (item._internalIdent !== internalId) return item
+        return { ...item, visible: false }
+      }),
+    )
+  }
+  const removeAll = () => {
+    updateToasts(last => last.map(toast => ({ ...toast, visible: false })))
+  }
+  const findToastOneByID = (id: string) => toasts.find(t => t.id === id)
+  const removeToastOneByID = (id: string) => {
+    updateToasts(last =>
+      last.map(toast => {
+        if (toast.id !== id) return toast
+        return {
+          ...toast,
+          visible: false,
         }
-        destoryStack = []
-        return []
-      })
-      clearTimeout(destoryTimer)
-    }, delay + 350)
+      }),
+    )
   }
 
-  const setToast = (toast: Toast): void => {
-    const id = `toast-${getId()}`
+  const setToast = (toast: ToastInput): void => {
+    const internalIdent = `toast-${getId()}`
     const delay = toast.delay || defaultToast.delay
-
-    const cancel = (id: string, delay: number) => {
-      updateToasts((currentToasts: Array<ToastWithID>) => {
-        return currentToasts.map(item => {
-          if (item.id !== id) return item
-          return { ...item, willBeDestroy: true }
-        })
-      })
-      destoryStack.push(id)
-      destoryAll(delay, performance.now())
-    }
-
-    updateToasts((currentToasts: Array<ToastWithID>) => {
-      const newToast = {
-        ...toast,
-        id,
-        delay,
-        cancel: () => cancel(id, delay),
+    if (toast.id) {
+      const hasIdent = toasts.find(t => t.id === toast.id)
+      if (hasIdent) {
+        throw new Error('Toast: Already have the same key: "ident"')
       }
-      return [...currentToasts, newToast]
-    })
-
-    const hideToast = (id: string, delay: number) => {
-      const hideTimer = window.setTimeout(() => {
-        if (hoveringRef.current) {
-          hideToast(id, delay)
-          return clearTimeout(hideTimer)
-        }
-        cancel(id, delay)
-        clearTimeout(hideTimer)
-      }, delay)
     }
 
-    hideToast(id, delay)
+    updateToasts((last: Array<Toast>) => {
+      const newToast: Toast = {
+        delay,
+        text: toast.text,
+        visible: true,
+        type: toast.type || defaultToast.type,
+        id: toast.id || internalIdent,
+        actions: toast.actions || [],
+        _internalIdent: internalIdent,
+        _timeout: window.setTimeout(() => {
+          cancel(internalIdent)
+          if (newToast._timeout) {
+            window.clearTimeout(newToast._timeout)
+            newToast._timeout = null
+          }
+        }, delay),
+        cancel: () => cancel(internalIdent),
+      }
+      return [...last, newToast]
+    })
   }
 
-  return [toasts, setToast]
+  return {
+    toasts,
+    setToast,
+    removeAll,
+    findToastOneByID,
+    removeToastOneByID,
+  }
 }
 
 export default useToasts

--- a/components/utils/use-geist-ui-context.ts
+++ b/components/utils/use-geist-ui-context.ts
@@ -1,25 +1,27 @@
 import React from 'react'
-import { ToastWithID } from '../use-toasts/toast-container'
+import { defaultToastLayout, ToastLayout, Toast } from '../use-toasts/use-toast'
 
-export type UpdateToastsFunction<T> = (fn: (toasts: Array<T>) => Array<T>) => any
+export type UpdateToastsFunction = (fn: (toasts: Array<Toast>) => Array<Toast>) => any
+export type UpdateToastsLayoutFunction = (
+  fn: (layout: Required<ToastLayout>) => Required<ToastLayout>,
+) => any
 
 export interface GeistUIContextParams {
-  toasts: Array<ToastWithID>
-  toastHovering: boolean
-  updateToasts: UpdateToastsFunction<ToastWithID>
-  updateToastHoverStatus: (fn: () => boolean) => void
+  toasts: Array<Toast>
+  updateToasts: UpdateToastsFunction
+  toastLayout: Required<ToastLayout>
+  updateToastLayout: UpdateToastsLayoutFunction
 }
 
 const defaultParams: GeistUIContextParams = {
   toasts: [],
-  toastHovering: false,
+  toastLayout: defaultToastLayout,
+  updateToastLayout: t => t,
   updateToasts: t => t,
-  updateToastHoverStatus: () => {},
 }
 
-export const GeistUIContent: React.Context<GeistUIContextParams> = React.createContext<GeistUIContextParams>(
-  defaultParams,
-)
+export const GeistUIContent: React.Context<GeistUIContextParams> =
+  React.createContext<GeistUIContextParams>(defaultParams)
 
 export const useGeistUIContext = (): GeistUIContextParams =>
   React.useContext<GeistUIContextParams>(GeistUIContent)

--- a/components/utils/use-geist-ui-context.ts
+++ b/components/utils/use-geist-ui-context.ts
@@ -5,12 +5,15 @@ export type UpdateToastsFunction = (fn: (toasts: Array<Toast>) => Array<Toast>) 
 export type UpdateToastsLayoutFunction = (
   fn: (layout: Required<ToastLayout>) => Required<ToastLayout>,
 ) => any
+export type UpdateToastsIDFunction = (fn: () => string | null) => any
 
 export interface GeistUIContextParams {
   toasts: Array<Toast>
   updateToasts: UpdateToastsFunction
   toastLayout: Required<ToastLayout>
   updateToastLayout: UpdateToastsLayoutFunction
+  lastUpdateToastId: string | null
+  updateLastToastId: UpdateToastsIDFunction
 }
 
 const defaultParams: GeistUIContextParams = {
@@ -18,6 +21,8 @@ const defaultParams: GeistUIContextParams = {
   toastLayout: defaultToastLayout,
   updateToastLayout: t => t,
   updateToasts: t => t,
+  lastUpdateToastId: null,
+  updateLastToastId: () => null,
 }
 
 export const GeistUIContent: React.Context<GeistUIContextParams> =

--- a/lib/components/customization/codes.tsx
+++ b/lib/components/customization/codes.tsx
@@ -34,7 +34,7 @@ const CustomizationCodes: React.FC<unknown> = () => {
   const { isChinese } = useConfigs()
   const codeTheme = makeCodeTheme(theme)
   const { copy } = useClipboard()
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
 
   const deepDifferents = useMemo(
     () => ({

--- a/lib/components/mdx-widgets/colors/index.tsx
+++ b/lib/components/mdx-widgets/colors/index.tsx
@@ -46,7 +46,7 @@ const getColorItem = (
 const Colors: React.FC<Props> = ({ type }) => {
   const theme = useTheme()
   const { copy } = useClipboard()
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const copyText = (text: string) => {
     copy(text)
     setToast({

--- a/lib/components/playground/editor.tsx
+++ b/lib/components/playground/editor.tsx
@@ -14,7 +14,7 @@ const Editor: React.FC<Props> = ({ code }) => {
   const { copy } = useClipboard()
   const { isChinese } = useConfigs()
   const [visible, setVisible] = useState(false)
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const clickHandler = (event: React.MouseEvent) => {
     event.stopPropagation()
     event.preventDefault()

--- a/pages/en-us/components/file-tree.mdx
+++ b/pages/en-us/components/file-tree.mdx
@@ -114,7 +114,7 @@ Display a list of files and folders in a hierarchical tree structure.
   scope={{ Tree, useToasts }}
   code={`
 () => {
-  const [_, setToast] = useToasts()
+  const { setToast } = useToasts()
   const handler = path => setToast({ text: path })
   return (
     <Tree onClick={handler}>

--- a/pages/en-us/hooks/use-clipboard.mdx
+++ b/pages/en-us/hooks/use-clipboard.mdx
@@ -16,7 +16,7 @@ This is custom React hooks, you need to follow the <Link target="_blank" color h
   scope={{ useClipboard, Button, useToasts }}
   code={`
 () => {
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const { copy } = useClipboard()
   const handler = () => {
     copy('hello, geist-ui')

--- a/pages/en-us/hooks/use-toast.mdx
+++ b/pages/en-us/hooks/use-toast.mdx
@@ -1,5 +1,5 @@
 import { Layout, Playground, Attributes } from 'lib/components'
-import { useToasts, Button, Spacer } from 'components'
+import { useToasts, Button, Spacer, Link } from 'components'
 
 export const meta = {
   title: 'useToast',
@@ -16,9 +16,9 @@ Display an important message globally.
   scope={{ Button, useToasts }}
   code={`
 () => {
-  const [toasts, setToast] = useToasts()
-  const click = () => setToast({ text: 'HTTP is stateless, but not sessionless.' })
-  return <Button onClick={click}>Show Toast</Button>
+  const { setToast } = useToasts()
+  const click = () => setToast({ text: 'HTTP is stateless, but not sessionless.', delay: 2000 })
+  return <Button scale={2/3} auto onClick={click}>Show Toast</Button>
 }
 `}
 />
@@ -29,9 +29,9 @@ Display an important message globally.
   scope={{ Button, useToasts }}
   code={`
 () => {
-  const [toasts, setToast] = useToasts()
+  const { setToast } = useToasts()
   const click = () => setToast({ text: 'HTTP is a protocol which allows the fetching of resources, such as HTML documents. It is the foundation of any data exchange on the Web and it is a client-server protocol, which means requests are initiated by the recipient, usually the Web browser. A complete document is reconstructed from the different sub-documents fetched, for instance text, layout description, images, videos, scripts, and more.' })
-  return <Button onClick={click}>Show Toast</Button>
+  return <Button scale={2/3} auto onClick={click}>Show Toast</Button>
 }
 `}
 />
@@ -42,7 +42,7 @@ Display an important message globally.
   scope={{ Button, useToasts }}
   code={`
 () => {
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const action = {
     name: 'alert',
     handler: () => alert('alert from toast')
@@ -51,7 +51,7 @@ Display an important message globally.
     text: 'HTTP is stateless, but not sessionless.',
     actions: [action],
   })
-  return <Button onClick={click} type="secondary">Show Action</Button>
+  return <Button scale={2/3} auto onClick={click} type="secondary">Show Action</Button>
 }
 `}
 />
@@ -62,7 +62,7 @@ Display an important message globally.
   scope={{ Button, useToasts }}
   code={`
 () => {
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const action = {
     name: 'cancel',
     passive: true,
@@ -72,7 +72,23 @@ Display an important message globally.
     text: 'HTTP is stateless, but not sessionless.',
     actions: [action],
   })
-  return <Button onClick={click}>Show Toast</Button>
+  return <Button scale={2/3} auto onClick={click}>Show Toast</Button>
+}
+`}
+/>
+
+<Playground
+  title="ReactNode"
+  desc="Show more information by replacing the string with a `ReactNode`."
+  scope={{ Button, useToasts, Link }}
+  code={`
+() => {
+  const { setToast } = useToasts()
+  const click = () => setToast({
+    text: <p>Click the <Link target="_blank" color block href="https://github.com/geist-org/geist-ui">URL</Link> to learn more</p>,
+    delay: 4000,
+  })
+  return <Button scale={2/3} auto onClick={click}>Show Toast</Button>
 }
 `}
 />
@@ -82,16 +98,16 @@ Display an important message globally.
   scope={{ Button, useToasts, Spacer }}
   code={`
 () => {
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const click = type => setToast({
     text: 'HTTP is stateless, but not sessionless.',
     type,
   })
   return (
     <>
-    <Button onClick={() => click('success')} type="success">Show Success</Button>
-    <Spacer h={.5} />
-    <Button onClick={() => click('warning')} type="warning">Show Warning</Button>
+    <Button scale={2/3} auto onClick={() => click('success')} type="success">Show Success</Button>
+    <Spacer inline w={.5} />
+    <Button scale={2/3} auto onClick={() => click('warning')} type="warning">Show Warning</Button>
     </>
   )
 }
@@ -102,35 +118,66 @@ Display an important message globally.
 <Attributes.Title>useToasts</Attributes.Title>
 
 ```ts
-const [toasts: Array<Toast>, setToast: (toast: Toast) => void] = useToasts()
+const {
+  // All Toasts currently in DOM
+  toasts: Array<Toast>
+
+  // Set a displayable Toast
+  setToast: (toast: ToastInput) => void
+
+  // Hide all Toast immediately
+  removeAll: () => void
+
+  // Query by id to get an instance of Toast
+  findToastOneByID: (ident: string) => Toast | undefined
+
+  // Remove the specified Toast by id
+  removeToastOneByID: (ident: string) => void
+} = useToasts(layout: ToastLayout)
 ```
 
-<Attributes.Title>Toast</Attributes.Title>
+<Attributes.Title>ToastLayout</Attributes.Title>
 
-  ```ts
-  interface Toast {
-    text?: string
-    type?: ToastTypes
-    delay?: number
-    actions?: Array<ToastAction>
-  }
-  ```
+| Option        | Description                  | Type                              | Default       |
+| ------------- | ---------------------------- | --------------------------------- | ------------- |
+| **padding**   | CSS properties               | `string`                          | -             |
+| **margin**    | CSS properties               | `string`                          | -             |
+| **width**     | CSS properties               | `string`                          | -             |
+| **maxWidth**  | CSS properties               | `string`                          | `90vw`        |
+| **maxHeight** | CSS properties               | `string`                          | `75px`        |
+| **placement** | the pop-up position of toast | [ToastPlacement](#toastplacement) | `bottomRight` |
 
-  <Attributes.Title>ToastAction</Attributes.Title>
+<Attributes.Title>ToastInput</Attributes.Title>
 
-  ```ts
-  interface ToastAction {
-    name: string
-    handler: (event: React.MouseEventHandler<HTMLButtonElement>, cancel: Function) => void
-    passive?: boolean
-  }
-  ```
+| Option      | Description                                  | Type                        | Default   |
+| ----------- | -------------------------------------------- | --------------------------- | --------- |
+| **id**      | unique identifier that can be auto generated | `string`                    | -         |
+| **text**    | content displayed in toast                   | `string`, `ReactNode`       | -         |
+| **type**    | the type of toast                            | [ToastTypes](#toasttypes)   | `default` |
+| **delay**   | close after a specified time                 | `number`                    | `2000`    |
+| **actions** | specify a default action                     | [ToastAction](#toastaction) | -         |
 
-  <Attributes.Title>ToastTypes</Attributes.Title>
+<Attributes.Title>ToastPlacement</Attributes.Title>
 
-  ```ts
-  type ToastTypes = 'default' | 'secondary' | 'success' | 'warning' | 'error'
-  ```
+```ts
+type ToastPlacement = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight'
+```
+
+<Attributes.Title>ToastAction</Attributes.Title>
+
+```ts
+interface ToastAction {
+  name: string
+  handler: (event: React.MouseEventHandler<HTMLButtonElement>, cancel: Function) => void
+  passive?: boolean
+}
+```
+
+<Attributes.Title>ToastTypes</Attributes.Title>
+
+```ts
+type ToastTypes = 'default' | 'secondary' | 'success' | 'warning' | 'error'
+```
 
 </Attributes>
 

--- a/pages/zh-cn/components/file-tree.mdx
+++ b/pages/zh-cn/components/file-tree.mdx
@@ -114,7 +114,7 @@ export const meta = {
   scope={{ Tree, useToasts }}
   code={`
 () => {
-  const [_, setToast] = useToasts()
+  const { setToast } = useToasts()
   const handler = path => setToast({ text: path })
   return (
     <Tree onClick={handler}>

--- a/pages/zh-cn/hooks/use-clipboard.mdx
+++ b/pages/zh-cn/hooks/use-clipboard.mdx
@@ -14,7 +14,7 @@ export const meta = {
   scope={{ useClipboard, Button, useToasts }}
   code={`
 () => {
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const { copy } = useClipboard()
   const handler = () => {
     copy('hello, geist-ui')

--- a/pages/zh-cn/hooks/use-toast.mdx
+++ b/pages/zh-cn/hooks/use-toast.mdx
@@ -1,5 +1,5 @@
 import { Layout, Playground, Attributes } from 'lib/components'
-import { useToasts, Button, Spacer } from 'components'
+import { useToasts, Button, Spacer, Link } from 'components'
 
 export const meta = {
   title: '通知 useToast',
@@ -16,9 +16,9 @@ export const meta = {
   scope={{ Button, useToasts }}
   code={`
 () => {
-  const [toasts, setToast] = useToasts()
+  const { setToast } = useToasts()
   const click = () => setToast({ text: '你正在浏览文档站点。' })
-  return <Button onClick={click}>显示通知</Button>
+  return <Button scale={2/3} auto onClick={click}>显示通知</Button>
 }
 `}
 />
@@ -29,9 +29,9 @@ export const meta = {
   scope={{ Button, useToasts }}
   code={`
 () => {
-  const [toasts, setToast] = useToasts()
+  const { setToast } = useToasts()
   const click = () => setToast({ text: 'CSS是一门基于规则的语言 —— 你能定义用于你的网页中特定元素样式的一组规则. 比如“我希望页面中的主标题是红色的大字”' })
-  return <Button onClick={click}>显示通知</Button>
+  return <Button scale={2/3} auto onClick={click}>显示通知</Button>
 }
 `}
 />
@@ -42,7 +42,7 @@ export const meta = {
   scope={{ Button, useToasts }}
   code={`
 () => {
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const action = {
     name: '点击我',
     handler: () => alert('由 Toast / 通知组件触发。')
@@ -51,7 +51,7 @@ export const meta = {
     text: '我正在浏览文档站点。',
     actions: [action],
   })
-  return <Button onClick={click} type="secondary">显示通知</Button>
+  return <Button scale={2/3} auto onClick={click} type="secondary">显示通知</Button>
 }
 `}
 />
@@ -62,7 +62,7 @@ export const meta = {
   scope={{ Button, useToasts }}
   code={`
 () => {
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const action = {
     name: '取消',
     passive: true,
@@ -72,7 +72,23 @@ export const meta = {
     text: '我正在浏览文档站点。',
     actions: [action],
   })
-  return <Button onClick={click}>显示通知</Button>
+  return <Button scale={2/3} auto onClick={click}>显示通知</Button>
+}
+`}
+/>
+
+<Playground
+  title="自定义模板"
+  desc="以 `ReactNode` 代替字符串展示更丰富的信息。"
+  scope={{ Button, useToasts, Link }}
+  code={`
+() => {
+  const { setToast } = useToasts()
+  const click = () => setToast({
+    text: <p>点击此<Link target="_blank" color block href="https://github.com/geist-org/geist-ui">链接</Link>了解更多信息</p>,
+    delay: 4000,
+  })
+  return <Button scale={2/3} auto onClick={click}>显示通知</Button>
 }
 `}
 />
@@ -82,16 +98,16 @@ export const meta = {
   scope={{ Button, useToasts, Spacer }}
   code={`
 () => {
-  const [, setToast] = useToasts()
+  const { setToast } = useToasts()
   const click = type => setToast({
     text: '我正在浏览文档站点。',
     type,
   })
   return (
     <>
-    <Button onClick={() => click('success')} type="success">显示成功状态</Button>
-    <Spacer h={.5} />
-    <Button onClick={() => click('warning')} type="warning">显示警告状态</Button>
+    <Button scale={2/3} auto onClick={() => click('success')} type="success">显示成功状态</Button>
+    <Spacer inline x={.5} />
+    <Button scale={2/3} auto onClick={() => click('warning')} type="warning">显示警告状态</Button>
     </>
   )
 }
@@ -102,18 +118,49 @@ export const meta = {
 <Attributes.Title>useToasts</Attributes.Title>
 
 ```ts
-const [toasts: Array<Toast>, setToast: (toast: Toast) => void] = useToasts()
+const {
+  // 当前 DOM 中所有可用实例
+  toasts: Array<Toast>
+
+  // 创建一个立即显示的通知
+  setToast: (toast: ToastInput) => void
+
+  // 立刻隐藏所有的通知
+  removeAll: () => void
+
+  // 按 ID 查询指定的实例
+  findToastOneByID: (ident: string) => Toast | undefined
+
+  // 按 ID 移除一个指定通知
+  removeToastOneByID: (ident: string) => void
+} = useToasts(layout: ToastLayout)
 ```
 
-<Attributes.Title>Toast</Attributes.Title>
+<Attributes.Title>ToastLayout</Attributes.Title>
+
+| 参数          | 描述           | 类型                              | 默认值        |
+| ------------- | -------------- | --------------------------------- | ------------- |
+| **padding**   | 通用 CSS 属性  | `string`                          | -             |
+| **margin**    | 通用 CSS 属性  | `string`                          | -             |
+| **width**     | 通用 CSS 属性  | `string`                          | -             |
+| **maxWidth**  | 通用 CSS 属性  | `string`                          | `90vw`        |
+| **maxHeight** | 通用 CSS 属性  | `string`                          | `75px`        |
+| **placement** | 组件弹出的位置 | [ToastPlacement](#toastplacement) | `bottomRight` |
+
+<Attributes.Title>ToastInput</Attributes.Title>
+
+| 参数        | 描述                    | 类型                        | 默认值    |
+| ----------- | ----------------------- | --------------------------- | --------- |
+| **id**      | 唯一识别 ID，可自动生成 | `string`                    | -         |
+| **text**    | 组件内显示的信息        | `string`, `ReactNode`       | -         |
+| **type**    | 组件的样式类型          | [ToastTypes](#toasttypes)   | `default` |
+| **delay**   | 自动关闭前等待的时间    | `number`                    | `2000`    |
+| **actions** | 指定一个默认的动作      | [ToastAction](#toastaction) | -         |
+
+<Attributes.Title>ToastPlacement</Attributes.Title>
 
 ```ts
-interface Toast {
-  text?: string
-  type?: ToastTypes
-  delay?: number
-  actions?: Array<ToastAction>
-}
+type ToastPlacement = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight'
 ```
 
 <Attributes.Title>ToastAction</Attributes.Title>
@@ -133,6 +180,5 @@ type ToastTypes = 'default' \| 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 </Attributes>
-
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

- Add `placement` support.
- Add `ReactNode` support.
- Allow users to modify the global style of Toast. (`useToast(styles)`)
- Users can query the instance of Toast according to the specified ID and can manipulate the methods on the instance.
- Greatly optimized for Toast performance and stability.
