### PR TITLE
fix(search): remove global override of search styles

### DIFF
--- a/components/drawer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/index.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`Drawer customization should be supported 1`] = `
 `;
 
 exports[`Drawer should render correctly 1`] = `
-"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"content\\"><div class=\\"wrapper right  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><h2 class=\\"\\">Drawer</h2><style>
+"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"position\\"><div class=\\"wrapper right  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><h2 class=\\"\\">Drawer</h2><style>
         h2 {
           line-height: 1.6;
           font-weight: normal;
@@ -255,8 +255,7 @@ exports[`Drawer should render correctly 1`] = `
               box-sizing: border-box;
               text-align: center;
             }
-
-            .content {
+            .position {
               position: relative;
               z-index: 1001;
               outline: none;
@@ -266,7 +265,6 @@ exports[`Drawer should render correctly 1`] = `
               vertical-align: middle;
               display: inline-block;
             }
-
             .backdrop:before {
               display: inline-block;
               width: 0;
@@ -274,7 +272,6 @@ exports[`Drawer should render correctly 1`] = `
               vertical-align: middle;
               content: '';
             }
-
             .layer {
               position: fixed;
               top: 0;
@@ -289,19 +286,15 @@ exports[`Drawer should render correctly 1`] = `
               pointer-events: none;
               z-index: 1000;
             }
-
             .backdrop-wrapper-enter .layer {
               opacity: 0;
             }
-
             .backdrop-wrapper-enter-active .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave-active .layer {
               opacity: 0;
             }
@@ -309,7 +302,7 @@ exports[`Drawer should render correctly 1`] = `
 `;
 
 exports[`Drawer should work correctly with different placement 1`] = `
-"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"content\\"><div class=\\"wrapper top  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><p>Some content contained within the drawer.</p><div tabindex=\\"0\\" class=\\"hide-tab end\\" aria-hidden=\\"true\\"></div><style>
+"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"position\\"><div class=\\"wrapper top  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><p>Some content contained within the drawer.</p><div tabindex=\\"0\\" class=\\"hide-tab end\\" aria-hidden=\\"true\\"></div><style>
           .wrapper {
             position: fixed;
             top: 0;
@@ -404,8 +397,7 @@ exports[`Drawer should work correctly with different placement 1`] = `
               box-sizing: border-box;
               text-align: center;
             }
-
-            .content {
+            .position {
               position: relative;
               z-index: 1001;
               outline: none;
@@ -415,7 +407,6 @@ exports[`Drawer should work correctly with different placement 1`] = `
               vertical-align: middle;
               display: inline-block;
             }
-
             .backdrop:before {
               display: inline-block;
               width: 0;
@@ -423,7 +414,6 @@ exports[`Drawer should work correctly with different placement 1`] = `
               vertical-align: middle;
               content: '';
             }
-
             .layer {
               position: fixed;
               top: 0;
@@ -438,19 +428,15 @@ exports[`Drawer should work correctly with different placement 1`] = `
               pointer-events: none;
               z-index: 1000;
             }
-
             .backdrop-wrapper-enter .layer {
               opacity: 0;
             }
-
             .backdrop-wrapper-enter-active .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave-active .layer {
               opacity: 0;
             }
@@ -458,7 +444,7 @@ exports[`Drawer should work correctly with different placement 1`] = `
 `;
 
 exports[`Drawer should work correctly with different placement 2`] = `
-"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"content\\"><div class=\\"wrapper right  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><p>Some content contained within the drawer.</p><div tabindex=\\"0\\" class=\\"hide-tab end\\" aria-hidden=\\"true\\"></div><style>
+"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"position\\"><div class=\\"wrapper right  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><p>Some content contained within the drawer.</p><div tabindex=\\"0\\" class=\\"hide-tab end\\" aria-hidden=\\"true\\"></div><style>
           .wrapper {
             position: fixed;
             top: 0;
@@ -553,8 +539,7 @@ exports[`Drawer should work correctly with different placement 2`] = `
               box-sizing: border-box;
               text-align: center;
             }
-
-            .content {
+            .position {
               position: relative;
               z-index: 1001;
               outline: none;
@@ -564,7 +549,6 @@ exports[`Drawer should work correctly with different placement 2`] = `
               vertical-align: middle;
               display: inline-block;
             }
-
             .backdrop:before {
               display: inline-block;
               width: 0;
@@ -572,7 +556,6 @@ exports[`Drawer should work correctly with different placement 2`] = `
               vertical-align: middle;
               content: '';
             }
-
             .layer {
               position: fixed;
               top: 0;
@@ -587,19 +570,15 @@ exports[`Drawer should work correctly with different placement 2`] = `
               pointer-events: none;
               z-index: 1000;
             }
-
             .backdrop-wrapper-enter .layer {
               opacity: 0;
             }
-
             .backdrop-wrapper-enter-active .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave-active .layer {
               opacity: 0;
             }
@@ -607,7 +586,7 @@ exports[`Drawer should work correctly with different placement 2`] = `
 `;
 
 exports[`Drawer should work correctly with different placement 3`] = `
-"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"content\\"><div class=\\"wrapper bottom  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><p>Some content contained within the drawer.</p><div tabindex=\\"0\\" class=\\"hide-tab end\\" aria-hidden=\\"true\\"></div><style>
+"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"position\\"><div class=\\"wrapper bottom  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><p>Some content contained within the drawer.</p><div tabindex=\\"0\\" class=\\"hide-tab end\\" aria-hidden=\\"true\\"></div><style>
           .wrapper {
             position: fixed;
             top: 0;
@@ -702,8 +681,7 @@ exports[`Drawer should work correctly with different placement 3`] = `
               box-sizing: border-box;
               text-align: center;
             }
-
-            .content {
+            .position {
               position: relative;
               z-index: 1001;
               outline: none;
@@ -713,7 +691,6 @@ exports[`Drawer should work correctly with different placement 3`] = `
               vertical-align: middle;
               display: inline-block;
             }
-
             .backdrop:before {
               display: inline-block;
               width: 0;
@@ -721,7 +698,6 @@ exports[`Drawer should work correctly with different placement 3`] = `
               vertical-align: middle;
               content: '';
             }
-
             .layer {
               position: fixed;
               top: 0;
@@ -736,19 +712,15 @@ exports[`Drawer should work correctly with different placement 3`] = `
               pointer-events: none;
               z-index: 1000;
             }
-
             .backdrop-wrapper-enter .layer {
               opacity: 0;
             }
-
             .backdrop-wrapper-enter-active .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave-active .layer {
               opacity: 0;
             }
@@ -756,7 +728,7 @@ exports[`Drawer should work correctly with different placement 3`] = `
 `;
 
 exports[`Drawer should work correctly with different placement 4`] = `
-"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"content\\"><div class=\\"wrapper left  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><p>Some content contained within the drawer.</p><div tabindex=\\"0\\" class=\\"hide-tab end\\" aria-hidden=\\"true\\"></div><style>
+"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"position\\"><div class=\\"wrapper left  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab start\\" aria-hidden=\\"true\\"></div><p>Some content contained within the drawer.</p><div tabindex=\\"0\\" class=\\"hide-tab end\\" aria-hidden=\\"true\\"></div><style>
           .wrapper {
             position: fixed;
             top: 0;
@@ -851,8 +823,7 @@ exports[`Drawer should work correctly with different placement 4`] = `
               box-sizing: border-box;
               text-align: center;
             }
-
-            .content {
+            .position {
               position: relative;
               z-index: 1001;
               outline: none;
@@ -862,7 +833,6 @@ exports[`Drawer should work correctly with different placement 4`] = `
               vertical-align: middle;
               display: inline-block;
             }
-
             .backdrop:before {
               display: inline-block;
               width: 0;
@@ -870,7 +840,6 @@ exports[`Drawer should work correctly with different placement 4`] = `
               vertical-align: middle;
               content: '';
             }
-
             .layer {
               position: fixed;
               top: 0;
@@ -885,19 +854,15 @@ exports[`Drawer should work correctly with different placement 4`] = `
               pointer-events: none;
               z-index: 1000;
             }
-
             .backdrop-wrapper-enter .layer {
               opacity: 0;
             }
-
             .backdrop-wrapper-enter-active .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave-active .layer {
               opacity: 0;
             }

--- a/components/drawer/__tests__/use-modal.test.tsx
+++ b/components/drawer/__tests__/use-modal.test.tsx
@@ -4,11 +4,11 @@ import { Drawer, useModal } from 'components'
 import { updateWrapper } from 'tests/utils'
 
 export const expectDrawerIsOpened = (wrapper: ReactWrapper) => {
-  expect(wrapper.find('.content').length).not.toBe(0)
+  expect(wrapper.find('.position').length).not.toBe(0)
 }
 
 export const expectDrawerIsClosed = (wrapper: ReactWrapper) => {
-  expect(wrapper.find('.content').length).toBe(0)
+  expect(wrapper.find('.position').length).toBe(0)
 }
 
 describe('UseModal & Drawer', () => {

--- a/components/modal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/index.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Modal customization should be supported 1`] = `
 `;
 
 exports[`Modal should render correctly 1`] = `
-"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"content\\"><div class=\\"wrapper  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab\\" aria-hidden=\\"true\\"></div><h2 class=\\"\\">Modal</h2><style>
+"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"position\\"><div class=\\"wrapper  wrapper-enter\\" role=\\"dialog\\" tabindex=\\"-1\\"><div tabindex=\\"0\\" class=\\"hide-tab\\" aria-hidden=\\"true\\"></div><h2 class=\\"\\">Modal</h2><style>
         h2 {
           line-height: 1.6;
           font-weight: normal;
@@ -350,8 +350,7 @@ exports[`Modal should render correctly 1`] = `
               box-sizing: border-box;
               text-align: center;
             }
-
-            .content {
+            .position {
               position: relative;
               z-index: 1001;
               outline: none;
@@ -361,7 +360,6 @@ exports[`Modal should render correctly 1`] = `
               vertical-align: middle;
               display: inline-block;
             }
-
             .backdrop:before {
               display: inline-block;
               width: 0;
@@ -369,7 +367,6 @@ exports[`Modal should render correctly 1`] = `
               vertical-align: middle;
               content: '';
             }
-
             .layer {
               position: fixed;
               top: 0;
@@ -384,19 +381,15 @@ exports[`Modal should render correctly 1`] = `
               pointer-events: none;
               z-index: 1000;
             }
-
             .backdrop-wrapper-enter .layer {
               opacity: 0;
             }
-
             .backdrop-wrapper-enter-active .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave-active .layer {
               opacity: 0;
             }

--- a/components/modal/modal.tsx
+++ b/components/modal/modal.tsx
@@ -18,12 +18,18 @@ interface Props {
   visible?: boolean
   keyboard?: boolean
   wrapClassName?: string
+  positionClassName?: string
+  backdropClassName?: string
+  layerClassName?: string
 }
 
 const defaultProps = {
   wrapClassName: '',
   keyboard: true,
   disableBackdropClick: false,
+  positionClassName: '',
+  backdropClassName: '',
+  layerClassName: '',
 }
 
 type NativeAttrs = Omit<React.HTMLAttributes<any>, keyof Props>
@@ -37,6 +43,9 @@ const ModalComponent: React.FC<React.PropsWithChildren<ModalProps>> = ({
   wrapClassName,
   onContentClick,
   disableBackdropClick,
+  positionClassName,
+  backdropClassName,
+  layerClassName,
 }: React.PropsWithChildren<ModalProps> & typeof defaultProps) => {
   const portal = usePortal('modal')
   const { SCALES } = useScale()
@@ -86,6 +95,9 @@ const ModalComponent: React.FC<React.PropsWithChildren<ModalProps>> = ({
         onContentClick={onContentClick}
         visible={visible}
         width={SCALES.width(26)}
+        positionClassName={positionClassName}
+        backdropClassName={backdropClassName}
+        layerClassName={layerClassName}
         {...bindings}>
         <ModalWrapper visible={visible} className={wrapClassName}>
           {withoutActionsChildren}

--- a/components/shared/__tests__/__snapshots__/backdrop.test.tsx.snap
+++ b/components/shared/__tests__/__snapshots__/backdrop.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Backdrop should render correctly 1`] = `
-"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"content\\"><span>test-value</span></div><style>
+"<div class=\\"backdrop  backdrop-wrapper-enter\\"><div class=\\"layer\\"></div><div class=\\"position\\"><span>test-value</span></div><style>
             .backdrop {
               position: fixed;
               top: 0;
@@ -14,8 +14,7 @@ exports[`Backdrop should render correctly 1`] = `
               box-sizing: border-box;
               text-align: center;
             }
-
-            .content {
+            .position {
               position: relative;
               z-index: 1001;
               outline: none;
@@ -25,7 +24,6 @@ exports[`Backdrop should render correctly 1`] = `
               vertical-align: middle;
               display: inline-block;
             }
-
             .backdrop:before {
               display: inline-block;
               width: 0;
@@ -33,7 +31,6 @@ exports[`Backdrop should render correctly 1`] = `
               vertical-align: middle;
               content: '';
             }
-
             .layer {
               position: fixed;
               top: 0;
@@ -48,19 +45,15 @@ exports[`Backdrop should render correctly 1`] = `
               pointer-events: none;
               z-index: 1000;
             }
-
             .backdrop-wrapper-enter .layer {
               opacity: 0;
             }
-
             .backdrop-wrapper-enter-active .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave .layer {
               opacity: 0.25;
             }
-
             .backdrop-wrapper-leave-active .layer {
               opacity: 0;
             }

--- a/components/shared/__tests__/backdrop.test.tsx
+++ b/components/shared/__tests__/backdrop.test.tsx
@@ -55,7 +55,7 @@ describe('Backdrop', () => {
         <span>test-value</span>
       </Backdrop>,
     )
-    wrapper.find('.content').simulate('click', nativeEvent)
+    wrapper.find('.position').simulate('click', nativeEvent)
     expect(handler).toHaveBeenCalled()
     handler.mockRestore()
   })
@@ -72,7 +72,7 @@ describe('Backdrop', () => {
      * In simulation,`mousedown` and `mouseup`not directly triiger `click` event,
      * the click event below is just for simulation.
      */
-    wrapper.find('.content').simulate('mousedown')
+    wrapper.find('.position').simulate('mousedown')
     wrapper.find('.backdrop').simulate('click', nativeEvent)
     wrapper.find('.backdrop').simulate('mouseup')
     await updateWrapper(wrapper)

--- a/components/shared/backdrop.tsx
+++ b/components/shared/backdrop.tsx
@@ -2,18 +2,25 @@ import React, { MouseEvent } from 'react'
 import useTheme from '../use-theme'
 import CssTransition from './css-transition'
 import useCurrentState from '../utils/use-current-state'
+import useClasses from '../use-classes'
 
 interface Props {
   onClick?: (event: MouseEvent<HTMLElement>) => void
   visible?: boolean
   width?: string
   onContentClick?: (event: MouseEvent<HTMLElement>) => void
+  backdropClassName?: string
+  positionClassName?: string
+  layerClassName?: string
 }
 
 const defaultProps = {
   onClick: () => {},
   visible: false,
   onContentClick: () => {},
+  backdropClassName: '',
+  positionClassName: '',
+  layerClassName: '',
 }
 
 type NativeAttrs = Omit<React.HTMLAttributes<any>, keyof Props>
@@ -26,6 +33,9 @@ const Backdrop: React.FC<React.PropsWithChildren<BackdropProps>> = React.memo(
     visible,
     width,
     onContentClick,
+    backdropClassName,
+    positionClassName,
+    layerClassName,
     ...props
   }: React.PropsWithChildren<BackdropProps> & typeof defaultProps) => {
     const theme = useTheme()
@@ -45,14 +55,14 @@ const Backdrop: React.FC<React.PropsWithChildren<BackdropProps>> = React.memo(
     return (
       <CssTransition name="backdrop-wrapper" visible={visible} clearTime={300}>
         <div
-          className="backdrop"
+          className={useClasses('backdrop', backdropClassName)}
           onClick={clickHandler}
           onMouseUp={mouseUpHandler}
           {...props}>
-          <div className="layer" />
+          <div className={useClasses('layer', layerClassName)} />
           <div
             onClick={onContentClick}
-            className="content"
+            className={useClasses('position', positionClassName)}
             onMouseDown={() => setIsContentMouseDown(true)}>
             {children}
           </div>
@@ -69,8 +79,7 @@ const Backdrop: React.FC<React.PropsWithChildren<BackdropProps>> = React.memo(
               box-sizing: border-box;
               text-align: center;
             }
-
-            .content {
+            .position {
               position: relative;
               z-index: 1001;
               outline: none;
@@ -80,7 +89,6 @@ const Backdrop: React.FC<React.PropsWithChildren<BackdropProps>> = React.memo(
               vertical-align: middle;
               display: inline-block;
             }
-
             .backdrop:before {
               display: inline-block;
               width: 0;
@@ -88,7 +96,6 @@ const Backdrop: React.FC<React.PropsWithChildren<BackdropProps>> = React.memo(
               vertical-align: middle;
               content: '';
             }
-
             .layer {
               position: fixed;
               top: 0;
@@ -103,19 +110,15 @@ const Backdrop: React.FC<React.PropsWithChildren<BackdropProps>> = React.memo(
               pointer-events: none;
               z-index: 1000;
             }
-
             .backdrop-wrapper-enter .layer {
               opacity: 0;
             }
-
             .backdrop-wrapper-enter-active .layer {
               opacity: ${theme.expressiveness.portalOpacity};
             }
-
             .backdrop-wrapper-leave .layer {
               opacity: ${theme.expressiveness.portalOpacity};
             }
-
             .backdrop-wrapper-leave-active .layer {
               opacity: 0;
             }

--- a/components/use-modal/__tests__/use-modal.test.tsx
+++ b/components/use-modal/__tests__/use-modal.test.tsx
@@ -4,11 +4,11 @@ import { Modal, useModal } from 'components'
 import { updateWrapper } from 'tests/utils'
 
 export const expectModalIsOpened = (wrapper: ReactWrapper) => {
-  expect(wrapper.find('.content').length).not.toBe(0)
+  expect(wrapper.find('.position').length).not.toBe(0)
 }
 
 export const expectModalIsClosed = (wrapper: ReactWrapper) => {
-  expect(wrapper.find('.content').length).toBe(0)
+  expect(wrapper.find('.position').length).toBe(0)
 }
 
 describe('UseModal', () => {

--- a/lib/components/search/search.tsx
+++ b/lib/components/search/search.tsx
@@ -94,7 +94,12 @@ const Search: React.FC<unknown> = () => {
 
   return (
     <div className="container" {...KeyBindings}>
-      <Modal {...bindings} py={0} px={0.75} wrapClassName="search-menu">
+      <Modal
+        {...bindings}
+        py={0}
+        px={0.75}
+        wrapClassName="search-menu"
+        positionClassName="search-position">
         <Input
           ref={ref}
           w="100%"
@@ -131,35 +136,35 @@ const Search: React.FC<unknown> = () => {
         .container {
           visibility: hidden;
         }
-        .container:global(ul),
-        .container:global(li) {
+        :global(.search-menu ul),
+        :global(.search-menu li) {
           padding: 0;
           margin: 0;
           list-style: none;
         }
-        .container:global(.input-container.search-input) {
+        :global(.search-menu .input-container.search-input) {
           border: none;
           border-radius: 0;
         }
-        .container:global(.input-container div.input-wrapper) {
+        :global(.search-menu .input-container div.input-wrapper) {
           border: none;
           border-radius: 0;
         }
-        .container:global(.input-container .input-wrapper.hover) {
+        :global(.search-menu .input-container .input-wrapper.hover) {
           border: none;
         }
-        .container:global(.input-container .input-wrapper:active) {
+        :global(.search-menu .input-container .input-wrapper:active) {
           border: none;
         }
-        .container:global(.backdrop .content) {
-          position: absolute !important;
-          top: 100px !important;
-          left: 50% !important;
-          transform: translateX(-50%) !important;
-          transition: all 500ms ease !important;
+        :global(div.search-position.position) {
+          position: absolute;
+          top: 100px;
+          left: 50%;
+          transform: translateX(-50%);
+          transition: all 500ms ease;
           width: 500px;
         }
-        .container:global(.wrapper.search-menu) {
+        :global(.search-menu.wrapper) {
           box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.15), 0 -5px 20px 0 rgba(0, 0, 0, 0.15) !important;
         }
       `}</style>


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

- Adds more class-names compatibility to the Modal component, extending the interface downwards, which does not affect the existing behavior. Release these again in the next canary version.

