### PR TITLE
fix(card): remove fixed width of card content

### DIFF
--- a/components/card/__tests__/__snapshots__/footer.test.tsx.snap
+++ b/components/card/__tests__/__snapshots__/footer.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Card Footer should render correctly 1`] = `
 "<div class=\\"card\\"><div class=\\"content\\"><p>card</p><style>
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;

--- a/components/card/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/card/__tests__/__snapshots__/index.test.tsx.snap
@@ -40,7 +40,6 @@ LoadedCheerio {
                                 Node {
                                   "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -79,7 +78,6 @@ LoadedCheerio {
                               Node {
                                 "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -231,7 +229,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -270,7 +267,6 @@ LoadedCheerio {
                                 Node {
                                   "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -332,7 +328,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -377,7 +372,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -419,7 +413,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -458,7 +451,6 @@ LoadedCheerio {
                                 Node {
                                   "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -610,7 +602,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -649,7 +640,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -847,7 +837,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -886,7 +875,6 @@ LoadedCheerio {
                                 Node {
                                   "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1038,7 +1026,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1077,7 +1064,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1139,7 +1125,6 @@ LoadedCheerio {
                           Node {
                             "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1184,7 +1169,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1226,7 +1210,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1265,7 +1248,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1417,7 +1399,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1456,7 +1437,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1554,7 +1534,6 @@ LoadedCheerio {
                 Node {
                   "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1599,7 +1578,6 @@ LoadedCheerio {
               Node {
                 "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1651,7 +1629,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1690,7 +1667,6 @@ LoadedCheerio {
                                 Node {
                                   "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1842,7 +1818,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1881,7 +1856,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1943,7 +1917,6 @@ LoadedCheerio {
                           Node {
                             "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -1988,7 +1961,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2030,7 +2002,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2069,7 +2040,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2221,7 +2191,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2260,7 +2229,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2458,7 +2426,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2497,7 +2464,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2649,7 +2615,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2688,7 +2653,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2750,7 +2714,6 @@ LoadedCheerio {
                             Node {
                               "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2795,7 +2758,6 @@ LoadedCheerio {
                           Node {
                             "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2837,7 +2799,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -2876,7 +2837,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3028,7 +2988,6 @@ LoadedCheerio {
                                         Node {
                                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3067,7 +3026,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3311,7 +3269,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3350,7 +3307,6 @@ LoadedCheerio {
                                 Node {
                                   "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3502,7 +3458,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3541,7 +3496,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3603,7 +3557,6 @@ LoadedCheerio {
                           Node {
                             "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3648,7 +3601,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3690,7 +3642,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3729,7 +3680,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3881,7 +3831,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -3920,7 +3869,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4118,7 +4066,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4157,7 +4104,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4309,7 +4255,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4348,7 +4293,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4410,7 +4354,6 @@ LoadedCheerio {
                             Node {
                               "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4455,7 +4398,6 @@ LoadedCheerio {
                           Node {
                             "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4497,7 +4439,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4536,7 +4477,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4688,7 +4628,6 @@ LoadedCheerio {
                                         Node {
                                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4727,7 +4666,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4825,7 +4763,6 @@ LoadedCheerio {
                   Node {
                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4870,7 +4807,6 @@ LoadedCheerio {
                 Node {
                   "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4922,7 +4858,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -4961,7 +4896,6 @@ LoadedCheerio {
                                   Node {
                                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5113,7 +5047,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5152,7 +5085,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5214,7 +5146,6 @@ LoadedCheerio {
                             Node {
                               "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5259,7 +5190,6 @@ LoadedCheerio {
                           Node {
                             "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5301,7 +5231,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5340,7 +5269,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5492,7 +5420,6 @@ LoadedCheerio {
                                         Node {
                                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5531,7 +5458,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5729,7 +5655,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5768,7 +5693,6 @@ LoadedCheerio {
                                     Node {
                                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5920,7 +5844,6 @@ LoadedCheerio {
                                         Node {
                                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -5959,7 +5882,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6021,7 +5943,6 @@ LoadedCheerio {
                               Node {
                                 "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6066,7 +5987,6 @@ LoadedCheerio {
                             Node {
                               "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6108,7 +6028,6 @@ LoadedCheerio {
                                         Node {
                                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6147,7 +6066,6 @@ LoadedCheerio {
                                       Node {
                                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6299,7 +6217,6 @@ LoadedCheerio {
                                           Node {
                                             "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6338,7 +6255,6 @@ LoadedCheerio {
                                         Node {
                                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6594,7 +6510,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6633,7 +6548,6 @@ LoadedCheerio {
                   Node {
                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6785,7 +6699,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6824,7 +6737,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6898,7 +6810,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -6937,7 +6848,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7089,7 +6999,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7128,7 +7037,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7202,7 +7110,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7241,7 +7148,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7393,7 +7299,6 @@ LoadedCheerio {
                           Node {
                             "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7432,7 +7337,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7537,7 +7441,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7576,7 +7479,6 @@ LoadedCheerio {
                   Node {
                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7728,7 +7630,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7767,7 +7668,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7841,7 +7741,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -7880,7 +7779,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8032,7 +7930,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8071,7 +7968,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8157,7 +8053,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8196,7 +8091,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8348,7 +8242,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8387,7 +8280,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8480,7 +8372,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8519,7 +8410,6 @@ LoadedCheerio {
                   Node {
                     "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8671,7 +8561,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8710,7 +8599,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8786,7 +8674,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8825,7 +8712,6 @@ LoadedCheerio {
                     Node {
                       "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -8977,7 +8863,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -9016,7 +8901,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -9092,7 +8976,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -9131,7 +9014,6 @@ LoadedCheerio {
                       Node {
                         "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -9283,7 +9165,6 @@ LoadedCheerio {
                           Node {
                             "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;
@@ -9322,7 +9203,6 @@ LoadedCheerio {
                         Node {
                           "data": "
         .content {
-          width: 100%;
           height: auto;
           padding: calc(1 * 16px) calc(1 * 16px) calc(1 * 16px) calc(1 * 16px);
           margin: 0 0 0 0;

--- a/components/card/card-content.tsx
+++ b/components/card/card-content.tsx
@@ -25,7 +25,6 @@ const CardContentComponent: React.FC<React.PropsWithChildren<CardContentProps>> 
       {children}
       <style jsx>{`
         .content {
-          width: ${SCALES.width(1, '100%')};
           height: ${SCALES.height(1, 'auto')};
           padding: ${SCALES.pt(1)} ${SCALES.pr(1)} ${SCALES.pb(1)} ${SCALES.pl(1)};
           margin: ${SCALES.mt(0)} ${SCALES.mr(0)} ${SCALES.mb(0)} ${SCALES.ml(0)};


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information
When the `Card` component is nested with other components (eg: `Divider`, `Input`), the content will overflow the card due to the fixed width of the card content. For unknown reason, the error is not reproduced in the documentation.
![image](https://user-images.githubusercontent.com/22422393/153715367-8e75a8ca-73de-4f2f-97f0-1f8e8bf62efc.png)
```jsx
<>
  <Card width='600px'>
    <Card.Content>
      <Text>Login</Text>
      <Divider />
      <Grid.Container gap={1}>
        <Grid xs={24}>
          <Input icon={<Mail />} width='100%' />
        </Grid>
        <Grid xs={24}>
          <Input.Password icon={<Lock />} width='100%' />
        </Grid>
        <Grid xs={24}>
          <Button auto type='secondary'>
            Login
          </Button>
        </Grid>
      </Grid.Container>
    </Card.Content>
  </Card>
  <Card width='400px'>
    <Card.Content>
      <Text b my={0}>
        Description
      </Text>
    </Card.Content>
    <Divider h='1px' />
    <Card.Content>
      <Text>
        The Object constructor creates an object wrapper for the given
        value.
      </Text>
      <Text>
        When called in a non-constructor context, Object behaves identically
        to <Code>new Object()</Code>.
      </Text>
    </Card.Content>
  </Card>
</>
```
