### PR TITLE
chore(showcase): add AZ Software Company Homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ const Application = () => (
 - [SentiNEO: Near-Earth Objects Viewer](https://sentineo.app)
 - [Dashboard Design](https://github.com/ofekashery/react-dashboard-design)
 - [Regex-Vis: Regex visualizer & editor](https://github.com/Bowen7/regex-vis)
+- [AZ Software - Company homepage](https://azsoftware.org)
 - [Add here](https://github.com/geist-org/geist-ui/issues/new)
 
 ## LICENSE


### PR DESCRIPTION
Added my company homepage built on Geist and NextJS

## Checklist

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information
Add my company homepage (https://azsoftware.org) to showcases, built on Geist and NextJS
Here's a screenshot:

![image](https://user-images.githubusercontent.com/66299945/159163654-4a7945fb-641f-40a8-9f7c-3cdcfa2ea896.png)

With dark mode:

![image](https://user-images.githubusercontent.com/66299945/159163675-59651650-f77a-44c1-8955-204d6d1a75d8.png)

