### PR TITLE
fix: en-us document linked to zh-cn document

### DIFF
--- a/pages/en-us/guide/installation.mdx
+++ b/pages/en-us/guide/installation.mdx
@@ -91,7 +91,7 @@ export default App
 ```
 
 If you need server-side rendering in Next.js project,
-please refer to the [Server-side rendering](/zh-cn/guide/server-render) subsection to complete the configuration.
+please refer to the [Server-side rendering](/en-us/guide/server-render) subsection to complete the configuration.
 
 In addition, we have provided a complete [Next.js application](https://github.com/geist-org/geist-ui/blob/master/examples/create-next-app/README.md) example for reference.
 


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

fixed linking mistake