### PR TITLE
docs(guide): update nextjs guide for @types/react

### DIFF
--- a/pages/en-us/guide/server-render.mdx
+++ b/pages/en-us/guide/server-render.mdx
@@ -26,6 +26,7 @@ Then we add the following code to the file:
 
 ```js
 // NAME:pages/_document.js
+import { Fragment } from "react"
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import { CssBaseline } from '@geist-ui/core'
 
@@ -36,12 +37,12 @@ class MyDocument extends Document {
 
     return {
       ...initialProps,
-      styles: (
-        <>
+      styles: [
+        <Fragment key="1">
           {initialProps.styles}
           {styles}
-        </>
-      )
+        </Fragment>,
+      ],
     }
   }
 

--- a/pages/zh-cn/guide/server-render.mdx
+++ b/pages/zh-cn/guide/server-render.mdx
@@ -24,6 +24,7 @@ export const meta = {
 
 ```js
 // NAME:pages/_document.js
+import { Fragment } from "react"
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import { CssBaseline } from '@geist-ui/core'
 
@@ -34,12 +35,12 @@ class MyDocument extends Document {
 
     return {
       ...initialProps,
-      styles: (
-        <>
+      styles: [
+        <Fragment key="1">
           {initialProps.styles}
           {styles}
-        </>
-      )
+        </Fragment>,
+      ],
     }
   }
 


### PR DESCRIPTION
**Description**

Currently, the guide for Next.js in Server Render gives a type error after updating `@types/react` to `^18.0.0`. The overwrite of styles seems to be causing trouble. The `styles` are of type `styles?: ReactFragment | ReactElement<any, string | JSXElementConstructor<any>>[] | undefined instead of JSX.Element`.

**Screenshots**

![image](https://user-images.githubusercontent.com/86551248/173041507-014444ac-c241-4363-99d4-6ab2c3c36cf8.png)

![image](https://user-images.githubusercontent.com/86551248/173043083-8e0f15bc-844e-42c3-a2ef-45b77ac3ab07.png)
