### PR TITLE
fix(slider): trigger drag event should disabled click event

### DIFF
--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -149,4 +149,18 @@ describe('Slider', () => {
     let wrapper = mount(<Slider initialValue={20} hideValue />)
     expect(wrapper.html()).toMatchSnapshot()
   })
+  it('should not trigger click event when drag event is be called', async () => {
+    let value = 0
+    const changeHandler = jest.fn().mockImplementation(val => (value = val))
+    const wrapper = mount(<Slider initialValue={0} onChange={changeHandler} />)
+    const dot = wrapper.find('.dot').getDOMNode() as HTMLDivElement
+    act(() => triggerDrag(dot, 50))
+    wrapper.find('.slider').simulate('click', {
+      ...nativeEvent,
+      clientX: 51,
+    })
+    expect(changeHandler).toHaveBeenCalledTimes(1)
+    expect(value).toEqual(50)
+    changeHandler.mockRestore()
+  })
 })

--- a/components/slider/slider.tsx
+++ b/components/slider/slider.tsx
@@ -90,6 +90,7 @@ const SliderComponent: React.FC<React.PropsWithChildren<SliderProps>> = ({
   const [, setSliderWidth, sideWidthRef] = useCurrentState<number>(0)
   const [, setLastDargOffset, lastDargOffsetRef] = useCurrentState<number>(0)
   const [isClick, setIsClick] = useState<boolean>(false)
+  const [isDrag, setIsDrag] = useState<boolean>(false)
 
   const sliderRef = useRef<HTMLDivElement>(null)
   const dotRef = useRef<HTMLDivElement>(null)
@@ -124,6 +125,7 @@ const SliderComponent: React.FC<React.PropsWithChildren<SliderProps>> = ({
   }
   const dragStartHandler = () => {
     setIsClick(false)
+    setIsDrag(true)
     setSliderWidth(getRefWidth(sliderRef))
   }
   const dragEndHandler = (event: DraggingEvent) => {
@@ -137,6 +139,7 @@ const SliderComponent: React.FC<React.PropsWithChildren<SliderProps>> = ({
   const clickHandler = (event: React.MouseEvent<HTMLDivElement>) => {
     if (disabled) return
     if (!sliderRef || !sliderRef.current) return
+    if (isDrag) return setIsDrag(false)
     setIsClick(true)
     setSliderWidth(getRefWidth(sliderRef))
     const clickOffset = event.clientX - sliderRef.current.getBoundingClientRect().x


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)
- [x] Fix Slider trigger drag event can trigger click event cause update value twice time.

## Change information

cc. @unix 

#774 
