### PR TITLE
fix(docs): correct typo in table component

### DIFF
--- a/pages/en-us/components/table.mdx
+++ b/pages/en-us/components/table.mdx
@@ -196,7 +196,7 @@ const MyComponent = () => (
   <Table<User> data={data}>
     <Table.Column<User> prop="name" label="username" />
     <Table.Column<User> prop="role" label="role" />
-    <Table.Column<User> prop="reocrds" label="reocrds" render={renderHandler} />
+    <Table.Column<User> prop="records" label="records" render={renderHandler} />
   </Table>
 )
 ```

--- a/pages/zh-cn/components/table.mdx
+++ b/pages/zh-cn/components/table.mdx
@@ -193,7 +193,7 @@ const MyComponent = () => (
   <Table<User> data={data}>
     <Table.Column<User> prop="name" label="用户名" />
     <Table.Column<User> prop="role" label="角色" />
-    <Table.Column<User> prop="reocrds" label="记录" render={renderHandler} />
+    <Table.Column<User> prop="records" label="记录" render={renderHandler} />
   </Table>
 )
 ```


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors

## Change information

Small typo, replaced `reocrds` by `records` in the documentation of the table component.

