### PR TITLE
fix: add missing apostrophes to inter import

### DIFF
--- a/pages/en-us/guide/installation.mdx
+++ b/pages/en-us/guide/installation.mdx
@@ -114,7 +114,7 @@ Some fonts in Web applications do not render best on the _Windows_ platform, or 
 
 <Code block my={0} width="100%">
   <span className="token keyword module">import</span>{' '}
-  <span className="token string">inter-ui/inter.css</span>
+  <span className="token string">'inter-ui/inter.css'</span>
 </Code>
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>

--- a/pages/zh-cn/guide/installation.mdx
+++ b/pages/zh-cn/guide/installation.mdx
@@ -114,7 +114,7 @@ Web 应用中的一些字体在 _Windows_ 平台上无法得到最好的渲染�
 
 <Code block my={0} width="100%">
   <span className="token keyword module">import</span>{' '}
-  <span className="token string">inter-ui/inter.css</span>
+  <span className="token string">'inter-ui/inter.css'</span>
 </Code>
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>


### PR DESCRIPTION
## Checklist

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

- Add missing apostrophes to inter import

because it cant work like this:
![image](https://user-images.githubusercontent.com/54948363/197652201-a35a94de-f32c-4998-b4a7-b3d9cd92c80d.png)
