### PR TITLE
fix(docs): correct wrong color data: `Violet` -> `Magenta`

### DIFF
--- a/lib/components/mdx-widgets/colors/colors-data.ts
+++ b/lib/components/mdx-widgets/colors/colors-data.ts
@@ -55,7 +55,7 @@ const cyan: ColorEnum = {
 const highlight: ColorEnum = {
   alert: 'Alert',
   purple: 'Purple',
-  magenta: 'Violet',
+  magenta: 'Magenta',
 }
 
 const colorsData: { [key: string]: ColorEnum } = {


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

<img width="551" alt="Screen Shot 2022-10-25 at 10 27 56 PM" src="https://user-images.githubusercontent.com/32605822/197786865-35052cd5-7a03-4386-a5dd-756ed5cfaffb.png">

Correcting typo `Violet` -> `Magenta` in `highlight`.