### PR TITLE
🐞 fix: exclude `esm` instead of `es`

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -45,6 +45,6 @@
   "exclude": [
     "node_modules",
     "lib",
-    "es"
+    "esm"
   ]
 }

--- a/scripts/tsconfig.test.json
+++ b/scripts/tsconfig.test.json
@@ -31,6 +31,6 @@
   "exclude": [
     "node_modules",
     "lib",
-    "es"
+    "esm"
   ]
 }


### PR DESCRIPTION
## Checklist

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

I did not find a folder named `es` in the project. On the contrary, the `esm` folder generated during packaging, `tsc` should not compile this folder